### PR TITLE
feat: V8 coverage merge optimization and performance timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.3] - 2024-12-15
+
+### Added
+
+- **V8 coverage merge optimization** - Merge duplicate V8 coverage entries by URL before conversion
+  - Uses SUM strategy to accumulate execution counts across test runs
+  - Normalizes URLs by stripping query parameters (`?v=xxxxx`) for dev mode cache-busted chunks
+  - Reduces ~400 entries → ~60 unique entries in dev mode, ~178 → ~33 in production
+  - ~12% faster conversion, more accurate coverage
+- **Performance timing config** - New `timing: true` option to show only performance metrics without verbose debug output
+- **`createTimer()` utility** - Simple timer for measuring performance of coverage operations
+
+### Changed
+
+- **Replaced `acorn` with Vite's `parseAstAsync`** - Better TSX/JSX support and tree-shaking
+- **Regex patterns use dynamic construction** - Source map regex patterns in `constants.ts` are now built dynamically to avoid Vite's source map scanner detecting them as actual source maps (Windows Vite bug)
+
+### Removed
+
+- **Removed `acorn` dependency** - Replaced with Vite's built-in parser
+
 ## [0.6.2] - 2024-12-13
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@babel/parser": "^7.24.0",
         "@bcoe/v8-coverage": "^1.0.0",
         "@jridgewell/sourcemap-codec": "^1.4.0",
-        "acorn": "^8.12.0",
         "ast-v8-to-istanbul": "^0.3.0",
         "convert-source-map": "^2.0.0",
         "glob": "^11.0.0",
@@ -20,7 +19,8 @@
         "istanbul-lib-report": "^3.0.1",
         "istanbul-lib-source-maps": "^5.0.0",
         "istanbul-reports": "^3.1.0",
-        "monocart-coverage-reports": "^2.0.0"
+        "monocart-coverage-reports": "^2.0.0",
+        "vite": "^6.0.0"
       },
       "bin": {
         "nextcov": "dist/cli.js"
@@ -110,7 +110,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -127,7 +126,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -144,7 +142,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -161,7 +158,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -178,7 +174,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -195,7 +190,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -212,7 +206,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -229,7 +222,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -246,7 +238,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -263,7 +254,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -280,7 +270,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -297,7 +286,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -314,7 +302,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -331,7 +318,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -348,7 +334,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -365,7 +350,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -382,7 +366,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -399,7 +382,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -416,7 +398,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -433,7 +414,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -450,7 +430,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -467,7 +446,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -484,7 +462,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -501,7 +478,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -518,7 +494,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -535,7 +510,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -853,7 +827,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -867,7 +840,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -881,7 +853,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -895,7 +866,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -909,7 +879,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -923,7 +892,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -937,7 +905,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -951,7 +918,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -965,7 +931,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -979,7 +944,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -993,7 +957,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1007,7 +970,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1021,7 +983,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1035,7 +996,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1049,7 +1009,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1063,7 +1022,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1077,7 +1035,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1091,7 +1048,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1105,7 +1061,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1119,7 +1074,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1133,7 +1087,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1147,7 +1100,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1241,7 +1193,7 @@
       "version": "22.19.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
       "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1945,7 +1897,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2207,7 +2158,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -2292,7 +2242,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2709,7 +2658,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2857,14 +2805,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2909,7 +2855,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3006,7 +2951,6 @@
       "version": "4.53.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
       "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -3110,7 +3054,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -3272,7 +3215,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -3363,7 +3305,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/uri-js": {
@@ -3377,24 +3319,23 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.2.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.7.tgz",
-      "integrity": "sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==",
-      "dev": true,
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -3403,14 +3344,14 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
         "jiti": ">=1.21.0",
-        "less": "^4.0.0",
+        "less": "*",
         "lightningcss": "^1.21.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
         "terser": "^5.16.0",
         "tsx": "^4.8.1",
         "yaml": "^2.4.2"
@@ -3455,7 +3396,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcov",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Collect test coverage for Playwright E2E tests in Next.js applications",
   "author": "Steve Zhang",
   "license": "MIT",
@@ -57,7 +57,6 @@
     "@babel/parser": "^7.24.0",
     "@bcoe/v8-coverage": "^1.0.0",
     "@jridgewell/sourcemap-codec": "^1.4.0",
-    "acorn": "^8.12.0",
     "ast-v8-to-istanbul": "^0.3.0",
     "convert-source-map": "^2.0.0",
     "glob": "^11.0.0",
@@ -65,7 +64,8 @@
     "istanbul-lib-report": "^3.0.1",
     "istanbul-lib-source-maps": "^5.0.0",
     "istanbul-reports": "^3.1.0",
-    "monocart-coverage-reports": "^2.0.0"
+    "monocart-coverage-reports": "^2.0.0",
+    "vite": "^6.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/src/__tests__/converter.test.ts
+++ b/src/__tests__/converter.test.ts
@@ -699,15 +699,15 @@ describe('CoverageConverter', () => {
   })
 
   describe('addUncoveredFiles - error handling', () => {
-    it('should warn when source cannot be loaded', async () => {
-      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    it('should skip files that cannot be loaded without adding to coverage', async () => {
       const libCoverage = require('istanbul-lib-coverage')
       const coverageMap = libCoverage.createCoverageMap({})
 
+      // Try to add a non-existent file - should silently skip
       await converter.addUncoveredFiles(coverageMap, ['/non/existent/file.ts'])
 
-      expect(consoleSpy).toHaveBeenCalled()
-      consoleSpy.mockRestore()
+      // Coverage map should remain empty (file was skipped)
+      expect(coverageMap.files().length).toBe(0)
     })
   })
 
@@ -1026,15 +1026,14 @@ describe('CoverageConverter', () => {
     })
 
     it('should handle errors gracefully', async () => {
-      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const libCoverage = require('istanbul-lib-coverage')
       const coverageMap = libCoverage.createCoverageMap({})
 
-      // Try to add a non-existent file
+      // Try to add a non-existent file - should silently skip without throwing
       await testConverter.addUncoveredFiles(coverageMap, ['/non/existent/file.ts'])
 
-      expect(consoleSpy).toHaveBeenCalled()
-      consoleSpy.mockRestore()
+      // Coverage map should remain empty (file was skipped)
+      expect(coverageMap.files().length).toBe(0)
     })
   })
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -100,6 +100,13 @@ export interface NextcovConfig {
    * When true, shows detailed progress logs during coverage collection.
    */
   log?: boolean
+
+  /**
+   * Enable timing logs (default: false)
+   * When true, shows only performance timing information without verbose debug output.
+   * This is useful for profiling coverage processing without the noise of debug logs.
+   */
+  timing?: boolean
 }
 
 /**
@@ -140,6 +147,7 @@ export interface ResolvedNextcovConfig {
   reporters: ReporterType[]
   devMode: ResolvedDevModeOptions
   log: boolean
+  timing: boolean
 }
 
 const DEFAULT_OUTPUT_DIR = 'coverage/e2e'
@@ -176,6 +184,7 @@ export const DEFAULT_NEXTCOV_CONFIG: ResolvedNextcovConfig = {
   reporters: DEFAULT_REPORTERS,
   devMode: DEFAULT_DEV_MODE_OPTIONS,
   log: false,
+  timing: false,
 }
 
 /**
@@ -241,6 +250,7 @@ export function resolveNextcovConfig(config?: NextcovConfig, playwrightBaseUrl?:
     reporters: config?.reporters ?? DEFAULT_NEXTCOV_CONFIG.reporters,
     devMode: resolveDevModeOptions(config?.devMode, cdpPort, playwrightBaseUrl),
     log: config?.log ?? DEFAULT_NEXTCOV_CONFIG.log,
+    timing: config?.timing ?? DEFAULT_NEXTCOV_CONFIG.timing,
   }
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -108,33 +108,47 @@ export const SOURCE_MAP_LOOKBACK_LIMIT = 10000
  */
 export const SOURCE_MAPPING_URL_PATTERN = /\/\/[#@]\s*sourceMappingURL=(.+)$/m
 
+// Build data URL pattern parts separately to avoid Vite's source map scanner
+// detecting our regex patterns as actual source maps (Windows Vite bug)
+const DATA_PREFIX = 'data:'
+const APP_JSON = 'application/json'
+const CHARSET_OPT = '(?:charset=utf-8;)?'
+const BASE64_SUFFIX = 'base64,'
+
 /**
  * Regex pattern to extract inline base64 source map from code comments.
  * Matches data URLs with optional charset specification.
  * Captures the base64-encoded content.
  */
-export const INLINE_SOURCE_MAP_BASE64_PATTERN =
-  /\/\/[#@]\s*sourceMappingURL=data:application\/json;(?:charset=utf-8;)?base64,(.+)$/m
+export const INLINE_SOURCE_MAP_BASE64_PATTERN = new RegExp(
+  `\\/\\/[#@]\\s*sourceMappingURL=${DATA_PREFIX}${APP_JSON};${CHARSET_OPT}${BASE64_SUFFIX}(.+)$`,
+  'm'
+)
 
 /**
  * Regex pattern to parse a base64 data URL directly.
  * Used when the data URL has already been extracted from a sourceMappingURL comment.
  * Captures the base64-encoded content.
  */
-export const DATA_URL_BASE64_PATTERN = /^data:application\/json;(?:charset=utf-8;)?base64,(.+)$/
+export const DATA_URL_BASE64_PATTERN = new RegExp(
+  `^${DATA_PREFIX}${APP_JSON};${CHARSET_OPT}${BASE64_SUFFIX}(.+)$`
+)
 
 /**
  * Regex pattern to find inline base64 source map DataURLs.
  * Matches: //# sourceMappingURL=data:application/json;charset=utf-8;base64,<base64data>
  */
-export const INLINE_SOURCE_MAP_PATTERN =
-  /sourceMappingURL=data:application\/json[^,]*,([A-Za-z0-9+/=]+)/
+export const INLINE_SOURCE_MAP_PATTERN = new RegExp(
+  `sourceMappingURL=${DATA_PREFIX}${APP_JSON}[^,]*,([A-Za-z0-9+/=]+)`
+)
 
 /**
  * Global regex pattern for finding all inline source maps in a chunk.
  */
-export const INLINE_SOURCE_MAP_PATTERN_GLOBAL =
-  /sourceMappingURL=data:application\/json;charset=utf-8;base64,([A-Za-z0-9+/=]+)/g
+export const INLINE_SOURCE_MAP_PATTERN_GLOBAL = new RegExp(
+  `sourceMappingURL=${DATA_PREFIX}${APP_JSON};charset=utf-8;${BASE64_SUFFIX}([A-Za-z0-9+/=]+)`,
+  'g'
+)
 
 /**
  * Regex pattern to find Next.js chunk script URLs in HTML.

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,9 +3,11 @@
  *
  * Logs are disabled by default (log: false in config).
  * Set log: true in nextcov config to enable detailed logging.
+ * Set timing: true to show only performance timing information.
  */
 
 let loggingEnabled = false
+let timingEnabled = false
 
 /**
  * Set whether logging is enabled
@@ -15,10 +17,24 @@ export function setLogging(enabled: boolean): void {
 }
 
 /**
+ * Set whether timing logs are enabled
+ */
+export function setTiming(enabled: boolean): void {
+  timingEnabled = enabled
+}
+
+/**
  * Check if logging is enabled
  */
 export function isLoggingEnabled(): boolean {
   return loggingEnabled
+}
+
+/**
+ * Check if timing is enabled
+ */
+export function isTimingEnabled(): boolean {
+  return timingEnabled
 }
 
 /**
@@ -42,4 +58,18 @@ export function warn(...args: unknown[]): void {
  */
 export function error(...args: unknown[]): void {
   console.error(...args)
+}
+
+/**
+ * Simple timer utility for performance measurement.
+ * Outputs when either logging or timing is enabled.
+ */
+export function createTimer(label: string): () => void {
+  const start = performance.now()
+  return () => {
+    if (loggingEnabled || timingEnabled) {
+      const duration = performance.now() - start
+      console.log(`  ⏱ ${label}: ${duration.toFixed(0)}ms`)
+    }
+  }
 }

--- a/src/playwright/__tests__/fixture.test.ts
+++ b/src/playwright/__tests__/fixture.test.ts
@@ -6,7 +6,9 @@ import type { Page, TestInfo } from '@playwright/test'
 vi.mock('../../logger.js', () => ({
   log: vi.fn(),
   setLogging: vi.fn(),
+  setTiming: vi.fn(),
   isLoggingEnabled: vi.fn().mockReturnValue(false),
+  isTimingEnabled: vi.fn().mockReturnValue(false),
   warn: vi.fn(),
   error: vi.fn(),
 }))

--- a/src/playwright/fixture.ts
+++ b/src/playwright/fixture.ts
@@ -30,7 +30,7 @@ import {
   type DevServerCoverageEntry,
   type V8ServerCoverageEntry,
 } from '../collector/index.js'
-import { log, setLogging } from '../logger.js'
+import { log, setLogging, setTiming } from '../logger.js'
 
 /**
  * Module-level state for persisting between globalSetup and globalTeardown.
@@ -132,8 +132,9 @@ export async function startServerCoverage(
     ? config as ResolvedNextcovConfig
     : resolveNextcovConfig(config)
 
-  // Initialize logging from config
+  // Initialize logging and timing from config
   setLogging(resolved.log)
+  setTiming(resolved.timing)
 
   // Auto-detect dev mode vs production mode:
   // - Dev mode: next dev --inspect=9230 spawns worker on port 9231 (inspect port + 1)


### PR DESCRIPTION
- Add mergeV8CoverageByUrl() with SUM strategy to de-duplicate coverage entries
- Normalize URLs by stripping query params (?v=xxxxx) for dev mode chunks
- Reduces ~400 entries → ~60 unique in dev mode (~178 → ~33 in production)
- Add timing config option for performance profiling without verbose logs
- Add createTimer() utility for measuring coverage operation performance
- Replace acorn with Vite's parseAstAsync for better TSX support
- Fix regex patterns in constants.ts to avoid Vite source map scanner bug