### PR TITLE
feat: add InProcessV8Collector for same-process coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.0] - 2026-04-11
+
+### Added
+
+- **In-process V8 coverage collector** - New `InProcessV8Collector` class for collecting V8 coverage from the current Node.js process using the `inspector/promises` API. No CDP connection or separate server needed — ideal for Playwright mock tests where the code under test runs in the same process as the tests.
+  ```typescript
+  import { InProcessV8Collector, saveClientCoverage } from 'nextcov/playwright'
+
+  const collector = new InProcessV8Collector({ include: ['dist/'] })
+  await collector.start()
+  // ... run code under test ...
+  const coverage = await collector.collect()
+  await saveClientCoverage('server-0', coverage)
+  await collector.stop()
+  ```
+  Coverage entries match the standard `BaseCoverageEntry` format and can be saved via `saveClientCoverage()` for automatic processing by `finalizeCoverage()`.
+
 ## [1.2.1] - 2026-03-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Now you can finally see the complete coverage picture for your Next.js applicati
 - **Production mode support** - Works with `next build && next start` using external source maps
 - **Auto-detection** - Automatically detects dev vs production mode, no configuration needed
 - **V8 native coverage** - Uses Node.js built-in `NODE_V8_COVERAGE` for accurate server coverage
+- **In-process coverage** - Collect V8 coverage from code running in the same process (e.g., Playwright mock tests)
 - **Source map support** - Maps bundled code back to original TypeScript/JSX
 - **Vitest compatible** - Output merges seamlessly with Vitest coverage reports
 - **Playwright integration** - Simple fixtures for automatic coverage collection
@@ -116,6 +117,7 @@ During interactive setup, you'll be asked to choose a coverage mode:
 |------|-------------|----------|
 | **Full (client + server)** | Collects both browser and Node.js coverage | Next.js with `next dev` or `next start` |
 | **Client-only** | Only browser coverage, simpler setup | Vite apps, static sites, SPAs, deployed environments |
+| **In-process** | V8 coverage from the test process itself | Playwright mock tests where code under test runs in the same process |
 
 After running `init`, follow the next steps shown to start collecting coverage.
 
@@ -895,6 +897,35 @@ Finalizes coverage collection and generates reports. Call in globalTeardown.
 | `cleanup` | `boolean` | `true` | Clean up temp files |
 | `cdpPort` | `number` | `9230` | CDP port for triggering v8.takeCoverage() |
 | `log` | `boolean` | `false` | Enable verbose logging output |
+
+#### `InProcessV8Collector`
+
+Collects V8 coverage from code running in the current Node.js process. Uses the `inspector/promises` API — no CDP connection or separate server needed.
+
+Ideal for Playwright mock tests where the code under test is imported and executed in the same process as the tests.
+
+```typescript
+import { InProcessV8Collector, saveClientCoverage } from 'nextcov/playwright'
+
+// Worker-scoped Playwright fixture example:
+const collector = new InProcessV8Collector({ include: ['dist/'] })
+await collector.start()
+
+// ... tests run, exercising the code under test ...
+
+const coverage = await collector.collect()
+await saveClientCoverage('server-0', coverage)
+await collector.stop()
+```
+
+**Constructor options:**
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `include` | `string[]` | `[]` (all) | URL substrings to include |
+| `exclude` | `string[]` | `['node_modules']` | URL substrings to exclude |
+
+Coverage entries are saved via `saveClientCoverage()` and automatically picked up by `finalizeCoverage()`.
 
 ### Main API (`nextcov`)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcov",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Collect test coverage for Playwright E2E tests in Next.js applications",
   "author": "Steve Zhang",
   "license": "MIT",

--- a/src/collector/in-process.ts
+++ b/src/collector/in-process.ts
@@ -1,0 +1,139 @@
+/**
+ * In-Process V8 Coverage Collector
+ *
+ * Collects V8 coverage from the current Node.js process using the
+ * inspector API. No CDP connection needed — coverage is collected
+ * directly from the same process running the tests.
+ *
+ * Use case: Playwright mock tests that import and run the code under
+ * test in the same process (e.g., VS Code extension mock tests).
+ *
+ * Usage:
+ *   const collector = new InProcessV8Collector({ include: ['src/'] })
+ *   await collector.start()
+ *   // ... run tests ...
+ *   const coverage = await collector.collect()
+ *   await collector.stop()
+ */
+
+import { Session } from 'node:inspector/promises'
+import { readFileSync, existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import type { BaseCoverageEntry } from './cdp-utils.js'
+import { log } from '@/utils/logger.js'
+
+export interface InProcessCollectorConfig {
+  /** Glob patterns to include (matched against file URLs). Default: all files */
+  include?: string[]
+  /** Glob patterns to exclude. Default: ['node_modules'] */
+  exclude?: string[]
+}
+
+export type InProcessCoverageEntry = BaseCoverageEntry
+
+/**
+ * Collects V8 coverage from the current Node.js process.
+ *
+ * Starts precise coverage via the inspector Session API, then
+ * takes a snapshot when `collect()` is called. Filters results
+ * to only include project source files.
+ */
+export class InProcessV8Collector {
+  private session: Session | null = null
+  private config: Required<InProcessCollectorConfig>
+
+  constructor(config?: InProcessCollectorConfig) {
+    this.config = {
+      include: config?.include ?? [],
+      exclude: config?.exclude ?? ['node_modules'],
+    }
+  }
+
+  /**
+   * Start precise V8 coverage collection.
+   * Call this before any code under test executes.
+   */
+  async start(): Promise<void> {
+    this.session = new Session()
+    this.session.connect()
+    await this.session.post('Profiler.enable')
+    await this.session.post('Profiler.startPreciseCoverage', {
+      callCount: true,
+      detailed: true,
+    })
+    log('📊 In-process V8 coverage started')
+  }
+
+  /**
+   * Take a coverage snapshot and return filtered entries.
+   * Can be called multiple times — each call returns cumulative coverage.
+   */
+  async collect(): Promise<InProcessCoverageEntry[]> {
+    if (!this.session) return []
+
+    const { result } = await this.session.post('Profiler.takePreciseCoverage') as { result: Array<{ scriptId: string; url: string; functions: any[] }> }
+
+    const entries: InProcessCoverageEntry[] = []
+    for (const script of result) {
+      if (!this._shouldInclude(script.url)) continue
+
+      // Attach source code for source map resolution
+      let source: string | undefined
+      const filePath = this._urlToPath(script.url)
+      if (filePath && existsSync(filePath)) {
+        try { source = readFileSync(filePath, 'utf-8') } catch {}
+      }
+
+      entries.push({
+        url: script.url,
+        source,
+        functions: script.functions,
+      })
+    }
+
+    log(`  ✓ Collected ${entries.length} in-process coverage entries`)
+    return entries
+  }
+
+  /**
+   * Stop coverage collection and disconnect the inspector session.
+   */
+  async stop(): Promise<void> {
+    if (!this.session) return
+    await this.session.post('Profiler.stopPreciseCoverage')
+    await this.session.post('Profiler.disable')
+    this.session.disconnect()
+    this.session = null
+    log('📊 In-process V8 coverage stopped')
+  }
+
+  private _shouldInclude(url: string): boolean {
+    if (!url || url.startsWith('node:')) return false
+
+    for (const pattern of this.config.exclude) {
+      if (url.includes(pattern)) return false
+    }
+
+    if (this.config.include.length === 0) return true
+
+    for (const pattern of this.config.include) {
+      if (url.includes(pattern)) return true
+    }
+    return false
+  }
+
+  private _urlToPath(url: string): string | null {
+    try {
+      if (url.startsWith('file://')) return fileURLToPath(url)
+      return null
+    } catch {
+      return null
+    }
+  }
+}
+
+// ─── Factory ─────────────────────────────────────────────────────────────────
+
+export function createInProcessCollector(config?: InProcessCollectorConfig): InProcessV8Collector {
+  return new InProcessV8Collector(config)
+}

--- a/src/collector/index.ts
+++ b/src/collector/index.ts
@@ -40,6 +40,14 @@ export {
 } from './v8-server.js'
 
 export {
+  // In-process V8 collector (same-process coverage, no CDP)
+  InProcessV8Collector,
+  createInProcessCollector,
+  type InProcessCoverageEntry,
+  type InProcessCollectorConfig,
+} from './in-process.js'
+
+export {
   // CDP utilities
   isCdpPortAvailable,
   connectToCdp,

--- a/src/playwright/index.ts
+++ b/src/playwright/index.ts
@@ -17,5 +17,8 @@ export {
 // Re-export client coverage utilities for custom collection workflows
 export { saveClientCoverage, filterAppCoverage } from '@/collector/client.js'
 
+// Re-export in-process V8 collector for same-process coverage
+export { InProcessV8Collector, createInProcessCollector, type InProcessCoverageEntry, type InProcessCollectorConfig } from '@/collector/in-process.js'
+
 // Re-export loadNextcovConfig for convenience
 export { loadNextcovConfig, resolveNextcovConfig } from '@/utils/config.js'


### PR DESCRIPTION
## Summary
- New `InProcessV8Collector` class in `src/collector/in-process.ts` — uses `node:inspector/promises` Session API to collect V8 coverage from the current process
- Exported from `nextcov/playwright` alongside existing utilities
- Version bump to 1.3.0, changelog and README updated

## Use case
Playwright mock tests where the code under test runs in the same process as the tests (no separate server). Example: VS Code extension mock tests that import `Extension` directly.

## Integration
```typescript
const collector = new InProcessV8Collector({ include: ['dist/'] })
await collector.start()
// ... tests run ...
const coverage = await collector.collect()
await saveClientCoverage('server-0', coverage)
await collector.stop()
```

Coverage entries match `BaseCoverageEntry` format and are picked up by `finalizeCoverage()` automatically.

## Validated
Tested with playwright-repl VS Code mock tests — coverage went from 2.5% (client-only) to 65.3% statements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)