### PR TITLE
feat: v1.4.0 — Turbopack support, E2E coverage rebase, and merge fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.0] - 2026-06-29
+
+### Added
+
+- **Next.js 16 Turbopack production support** - Coverage collection and source map path normalization now handle `turbopack:///[project]/...` and `turbopack:///[root-of-the-server]/...` URL schemes emitted by Next.js 14+ dev mode and Next.js 16+ production Turbopack builds. Previously these paths fell through to the regex fallback and were silently dropped in some cases.
+
+- **Automatic E2E coverage structure rebase** - `nextcov merge` now automatically rebases coarser-structured E2E maps onto the richest available structure before merging. When Next.js 16 Turbopack's production optimizer collapses adjacent AST nodes, E2E coverage reports fewer Istanbul statements than the Vite/esbuild-instrumented unit/component coverage for the same files — inflating E2E-only percentages (e.g. 55% instead of 37%). The rebase step remaps E2E hit counts by `line:col` position onto the richer Vitest structure, restoring accurate denominators. No-op for webpack/Next.js 14-15 and Vite projects where all inputs already share the same structure. No configuration required.
+
+### Fixed
+
+- **Hashed chunk filter regression (Next.js 16 / Turbopack)** - The client coverage collector was incorrectly filtering out Turbopack app chunks whose content-hash started with a digit (e.g. `02ec7w~yl_u_a.js`). The chunk-exclusion regex was tightened from `/^\d+/` to `/^\d+-/` so only webpack-style vendor/lazy chunks (`878-abcdef.js`) are excluded. No impact on Next.js 14/15 webpack production builds.
+
+- **Inverted source-map ranges (Turbopack function inlining)** - Turbopack's function inlining can produce source-map segments that jump backwards, causing `ast-v8-to-istanbul` to emit statement/function/branch ranges where `end.line < start.line`. These appeared as phantom uncovered statements in HTML reports. They are now clamped to zero-width (`end = start`) — hit counts are preserved; phantom uncovered entries are eliminated. No-op for webpack builds.
+
+- **Merge structure selection (fewest-zeros strategy)** - `selectBestSource` now picks the coverage skeleton with the **fewest zero-hit statements** rather than the most total items. This ensures that when merging Vitest (unit + component) coverage with E2E coverage, the Vitest-instrumented skeleton (which has the correct source-accurate AST granularity) is always preferred over Turbopack's coarser compiled structure. Tie-breaking: fewest zeros → most hits → more items → later source.
+
 ## [1.3.0] - 2026-04-11
 
 ### Added

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   {
-    ignores: ['dist/**', 'node_modules/**', 'coverage/**'],
+    ignores: ['dist/**', 'node_modules/**', 'coverage/**', 'scripts/**'],
   },
   {
     files: ['src/**/*.ts'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextcov",
-  "version": "1.2.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nextcov",
-      "version": "1.2.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.24.0",
@@ -14,7 +14,7 @@
         "@bcoe/v8-coverage": "^1.0.0",
         "@inquirer/prompts": "^8.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.0",
-        "ast-v8-to-istanbul": "^0.3.10",
+        "ast-v8-to-istanbul": "^1.0.4",
         "chalk": "^4.1.2",
         "convert-source-map": "^2.0.0",
         "glob": "^11.1.0",
@@ -38,14 +38,14 @@
         "@types/istanbul-lib-source-maps": "^4.0.4",
         "@types/istanbul-reports": "^3.0.4",
         "@types/node": "^22.0.0",
-        "@vitest/coverage-v8": "^4.0.15",
+        "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^9.39.1",
         "rimraf": "^6.0.0",
         "tsc-alias": "^1.8.16",
         "tsup": "^8.5.1",
         "typescript": "^5.7.0",
         "typescript-eslint": "^8.49.0",
-        "vitest": "^4.0.15"
+        "vitest": "^4.1.9"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -100,30 +100,30 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -165,13 +165,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1954,30 +1954,29 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.16.tgz",
-      "integrity": "sha512-2rNdjEIsPRzsdu6/9Eq0AYAzYdpP6Bx9cje9tL3FE5XzXRQF1fNU9pe/1yE8fCrS0HD+fBtt6gLPh6LI57tX7A==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.0.16",
-        "ast-v8-to-istanbul": "^0.3.8",
+        "@vitest/utils": "4.1.9",
+        "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
-        "istanbul-lib-source-maps": "^5.0.6",
         "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.1",
+        "magicast": "^0.5.2",
         "obug": "^2.1.1",
-        "std-env": "^3.10.0",
-        "tinyrainbow": "^3.0.3"
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.0.16",
-        "vitest": "4.0.16"
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1986,31 +1985,31 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.16.tgz",
-      "integrity": "sha512-eshqULT2It7McaJkQGLkPjPjNph+uevROGuIMJdG3V+0BSR2w9u6J9Lwu+E8cK5TETlfou8GRijhafIMhXsimA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.16",
-        "@vitest/utils": "4.0.16",
-        "chai": "^6.2.1",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.16.tgz",
-      "integrity": "sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.16",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2019,7 +2018,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -2031,26 +2030,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.16.tgz",
-      "integrity": "sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.16.tgz",
-      "integrity": "sha512-VWEDm5Wv9xEo80ctjORcTQRJ539EGPB3Pb9ApvVRAY1U/WkHXmmYISqU5E79uCwcW7xYUV38gwZD+RV755fu3Q==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.16",
+        "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2058,13 +2057,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.16.tgz",
-      "integrity": "sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.16",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2073,9 +2073,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.16.tgz",
-      "integrity": "sha512-4jIOWjKP0ZUaEmJm00E0cOBLU+5WE0BpeNr3XN6TEF05ltro6NJqHWxXD0kA8/Zc8Nh23AT8WQxwNG+WeROupw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2083,14 +2083,15 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.16.tgz",
-      "integrity": "sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.16",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -2248,14 +2249,14 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.10.tgz",
-      "integrity": "sha512-p4K7vMz2ZSk3wN8l5o3y2bJAoZXT3VuJI5OLTATY/01CYWumWvwkUw0SqDBnNq6IiTO3qDa1eSQDibAV8g7XOQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
-        "js-tokens": "^9.0.1"
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2528,9 +2529,9 @@
       "license": "MIT"
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2753,9 +2754,9 @@
       }
     },
     "node_modules/expect-type": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3261,9 +3262,9 @@
       }
     },
     "node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -3415,14 +3416,14 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.1.tgz",
-      "integrity": "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
       }
     },
@@ -3629,15 +3630,18 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -4226,9 +4230,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4440,9 +4444,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5282,31 +5286,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.16.tgz",
-      "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.16",
-        "@vitest/mocker": "4.0.16",
-        "@vitest/pretty-format": "4.0.16",
-        "@vitest/runner": "4.0.16",
-        "@vitest/snapshot": "4.0.16",
-        "@vitest/spy": "4.0.16",
-        "@vitest/utils": "4.0.16",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
         "obug": "^2.1.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -5322,12 +5326,15 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.16",
-        "@vitest/browser-preview": "4.0.16",
-        "@vitest/browser-webdriverio": "4.0.16",
-        "@vitest/ui": "4.0.16",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -5348,6 +5355,12 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
         "@vitest/ui": {
           "optional": true
         },
@@ -5356,13 +5369,16 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },
     "node_modules/vitest/node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcov",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Collect test coverage for Playwright E2E tests in Next.js applications",
   "author": "Steve Zhang",
   "license": "MIT",
@@ -60,7 +60,7 @@
     "@bcoe/v8-coverage": "^1.0.0",
     "@inquirer/prompts": "^8.1.0",
     "@jridgewell/sourcemap-codec": "^1.4.0",
-    "ast-v8-to-istanbul": "^0.3.10",
+    "ast-v8-to-istanbul": "^1.0.4",
     "chalk": "^4.1.2",
     "convert-source-map": "^2.0.0",
     "glob": "^11.1.0",
@@ -81,14 +81,14 @@
     "@types/istanbul-lib-source-maps": "^4.0.4",
     "@types/istanbul-reports": "^3.0.4",
     "@types/node": "^22.0.0",
-    "@vitest/coverage-v8": "^4.0.15",
+    "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^9.39.1",
     "rimraf": "^6.0.0",
     "tsc-alias": "^1.8.16",
     "tsup": "^8.5.1",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.49.0",
-    "vitest": "^4.0.15"
+    "vitest": "^4.1.9"
   },
   "repository": {
     "type": "git",

--- a/scripts/diagnose-merge.mjs
+++ b/scripts/diagnose-merge.mjs
@@ -1,0 +1,291 @@
+/**
+ * Coverage merge regression diagnostic
+ *
+ * Usage:
+ *   node scripts/diagnose-merge.mjs \
+ *     --unit    <unit-coverage-final.json> \
+ *     --comp    <component-coverage-final.json> \
+ *     --e2e     <e2e-coverage-final.json> \
+ *     --merged  <merged-coverage-final.json>
+ *
+ * Finds statements/functions/branches that are covered in ANY of the
+ * source coverages (unit/comp/e2e) but are lost in the merged output.
+ */
+
+import { readFileSync } from 'node:fs'
+
+// Parse named args: --unit foo.json --comp bar.json etc.
+const args = process.argv.slice(2)
+const flags = {}
+for (let i = 0; i < args.length; i++) {
+  if (args[i].startsWith('--')) {
+    flags[args[i].slice(2)] = args[i + 1]
+    i++
+  }
+}
+
+const { unit: unitPath, comp: compPath, e2e: e2ePath, merged: mergedPath } = flags
+
+if (!mergedPath) {
+  console.error([
+    'Usage: node diagnose-merge.mjs \\',
+    '  --unit   <unit-coverage-final.json> \\',
+    '  --comp   <component-coverage-final.json> \\',
+    '  --e2e    <e2e-coverage-final.json> \\',
+    '  --merged <merged-coverage-final.json>',
+    '',
+    'At least --e2e and --merged are required. --unit and --comp are optional.',
+  ].join('\n'))
+  process.exit(1)
+}
+
+const load = (path, label) => {
+  if (!path) return null
+  try {
+    const data = JSON.parse(readFileSync(path, 'utf-8'))
+    console.log(`  Loaded ${label}: ${Object.keys(data).length} files`)
+    return data
+  } catch (e) {
+    console.error(`Failed to load ${label} at ${path}: ${e.message}`)
+    process.exit(1)
+  }
+}
+
+console.log('\nLoading coverage files...')
+const unit   = load(unitPath,   'unit')
+const comp   = load(compPath,   'component')
+const e2e    = load(e2ePath,    'e2e')
+const merged = load(mergedPath, 'merged')
+
+// All source coverages (non-null), in order. "covered" means covered in ANY of them.
+const sources = [unit, comp, e2e].filter(Boolean)
+const sourceLabels = [unit && 'unit', comp && 'comp', e2e && 'e2e'].filter(Boolean)
+
+if (sources.length === 0) {
+  console.error('Need at least one of --unit / --comp / --e2e')
+  process.exit(1)
+}
+
+// All files across all sources
+const allSourceFiles = new Set(sources.flatMap(s => Object.keys(s)))
+
+const issues = []
+
+for (const file of allSourceFiles) {
+  const mergedCov = merged[file]
+  if (!mergedCov) {
+    // Which sources had this file?
+    const inSources = sourceLabels.filter((_, i) => sources[i][file])
+    issues.push({
+      file,
+      type: 'FILE_MISSING_IN_MERGED',
+      detail: `Present in [${inSources.join(', ')}] but missing from merged`,
+    })
+    continue
+  }
+
+  // For each metric, find the "best" count from any source
+  // and check it made it into merged
+
+  // ── Statements ───────────────────────────────────────────────────────────
+  // Collect all statements covered across sources, keyed by exact location
+  const coveredStmts = new Map() // "line:col" -> { maxCount, label, unitLoc }
+  for (let si = 0; si < sources.length; si++) {
+    const srcCov = sources[si][file]
+    if (!srcCov) continue
+    for (const [key, loc] of Object.entries(srcCov.statementMap || {})) {
+      const count = srcCov.s[key] ?? 0
+      if (count === 0) continue
+      const locKey = `${loc.start.line}:${loc.start.column}`
+      const existing = coveredStmts.get(locKey)
+      if (!existing || count > existing.maxCount) {
+        coveredStmts.set(locKey, { maxCount: count, label: sourceLabels[si], loc })
+      }
+    }
+  }
+
+  for (const [locKey, { maxCount, label, loc }] of coveredStmts) {
+    // Find in merged by exact location
+    const mergedKey = Object.entries(mergedCov.statementMap || {}).find(([, mloc]) =>
+      mloc.start.line === loc.start.line && mloc.start.column === loc.start.column
+    )?.[0]
+
+    if (mergedKey === undefined) {
+      // Try line-only
+      const lineMatch = Object.entries(mergedCov.statementMap || {}).find(([, mloc]) =>
+        mloc.start.line === loc.start.line
+      )
+      issues.push({
+        file,
+        type: 'STMT_MISSING_IN_MERGED',
+        detail: `@ ${locKey} covered in ${label} (${maxCount}x) — not in merged statementMap${lineMatch ? ` (line ${loc.start.line} exists at different col ${lineMatch[1].start.column}, merged count=${mergedCov.s[lineMatch[0]] ?? 0})` : ''}`,
+      })
+      continue
+    }
+
+    const mergedCount = mergedCov.s[mergedKey] ?? 0
+    if (mergedCount === 0) {
+      issues.push({
+        file,
+        type: 'STMT_COUNT_LOST',
+        detail: `@ ${locKey}: best-source=${label}(${maxCount}) merged=0`,
+      })
+    }
+  }
+
+  // ── Functions ────────────────────────────────────────────────────────────
+  const coveredFns = new Map() // "line:col" -> { maxCount, label, fn }
+  for (let si = 0; si < sources.length; si++) {
+    const srcCov = sources[si][file]
+    if (!srcCov) continue
+    for (const [key, fn] of Object.entries(srcCov.fnMap || {})) {
+      const count = srcCov.f[key] ?? 0
+      if (count === 0) continue
+      const locKey = `${fn.loc.start.line}:${fn.loc.start.column}`
+      const existing = coveredFns.get(locKey)
+      if (!existing || count > existing.maxCount) {
+        coveredFns.set(locKey, { maxCount: count, label: sourceLabels[si], fn })
+      }
+    }
+  }
+
+  for (const [locKey, { maxCount, label, fn }] of coveredFns) {
+    const mergedKey = Object.entries(mergedCov.fnMap || {}).find(([, mfn]) =>
+      mfn.loc.start.line === fn.loc.start.line && mfn.loc.start.column === fn.loc.start.column
+    )?.[0]
+
+    if (mergedKey === undefined) {
+      const lineMatch = Object.entries(mergedCov.fnMap || {}).find(([, mfn]) =>
+        mfn.loc.start.line === fn.loc.start.line
+      )
+      issues.push({
+        file,
+        type: 'FN_MISSING_IN_MERGED',
+        detail: `"${fn.name}" @ ${locKey} covered in ${label} (${maxCount}x) — not in merged fnMap${lineMatch ? ` (line exists at col ${lineMatch[1].loc.start.column}, merged count=${mergedCov.f[lineMatch[0]] ?? 0})` : ''}`,
+      })
+      continue
+    }
+
+    const mergedCount = mergedCov.f[mergedKey] ?? 0
+    if (mergedCount === 0) {
+      issues.push({
+        file,
+        type: 'FN_COUNT_LOST',
+        detail: `"${fn.name}" @ ${locKey}: best-source=${label}(${maxCount}) merged=0`,
+      })
+    }
+  }
+
+  // ── Branches ─────────────────────────────────────────────────────────────
+  const coveredBranches = new Map() // "line:col" -> { bestCounts, label, branch }
+  for (let si = 0; si < sources.length; si++) {
+    const srcCov = sources[si][file]
+    if (!srcCov) continue
+    for (const [key, branch] of Object.entries(srcCov.branchMap || {})) {
+      const counts = srcCov.b[key] ?? []
+      if (!counts.some(c => c > 0)) continue
+      const locKey = `${branch.loc.start.line}:${branch.loc.start.column}`
+      const existing = coveredBranches.get(locKey)
+      if (!existing) {
+        coveredBranches.set(locKey, { bestCounts: counts, label: sourceLabels[si], branch })
+      } else {
+        // Merge: take max per arm
+        const merged2 = existing.bestCounts.map((c, i) => Math.max(c, counts[i] ?? 0))
+        coveredBranches.set(locKey, { bestCounts: merged2, label: sourceLabels[si], branch })
+      }
+    }
+  }
+
+  for (const [locKey, { bestCounts, label, branch }] of coveredBranches) {
+    const mergedKey = Object.entries(mergedCov.branchMap || {}).find(([, mb]) =>
+      mb.loc.start.line === branch.loc.start.line && mb.loc.start.column === branch.loc.start.column
+    )?.[0]
+
+    if (mergedKey === undefined) {
+      issues.push({
+        file,
+        type: 'BRANCH_MISSING_IN_MERGED',
+        detail: `"${branch.type}" @ ${locKey} covered in ${label} ${JSON.stringify(bestCounts)} — not in merged`,
+      })
+      continue
+    }
+
+    const mergedCounts = mergedCov.b[mergedKey] ?? []
+    const lost = bestCounts.some((c, i) => c > 0 && (mergedCounts[i] ?? 0) === 0)
+    if (lost) {
+      issues.push({
+        file,
+        type: 'BRANCH_COUNT_LOST',
+        detail: `"${branch.type}" @ ${locKey}: best=${JSON.stringify(bestCounts)} merged=${JSON.stringify(mergedCounts)}`,
+      })
+    }
+  }
+}
+
+// ── Output ────────────────────────────────────────────────────────────────────
+
+if (issues.length === 0) {
+  console.log('\n✅ No regressions found — all source coverage is preserved in merged output.')
+  process.exit(0)
+}
+
+const byType = {}
+for (const issue of issues) {
+  byType[issue.type] = byType[issue.type] ?? []
+  byType[issue.type].push(issue)
+}
+
+const typeOrder = [
+  'FILE_MISSING_IN_MERGED',
+  'FN_MISSING_IN_MERGED', 'FN_COUNT_LOST',
+  'STMT_MISSING_IN_MERGED', 'STMT_COUNT_LOST',
+  'BRANCH_MISSING_IN_MERGED', 'BRANCH_COUNT_LOST',
+]
+
+console.log(`\n❌ Found ${issues.length} coverage regressions:\n`)
+for (const type of typeOrder) {
+  const items = byType[type]
+  if (!items) continue
+  console.log(`── ${type} (${items.length}) ${'─'.repeat(Math.max(0, 50 - type.length))}`)
+  const byFile = {}
+  for (const item of items) {
+    const short = item.file.replace(/.*[/\\]src[/\\]/, 'src/')
+    byFile[short] = byFile[short] ?? []
+    byFile[short].push(item.detail)
+  }
+  for (const [file, details] of Object.entries(byFile)) {
+    console.log(`  ${file}`)
+    for (const d of details.slice(0, 5)) console.log(`    ${d}`)
+    if (details.length > 5) console.log(`    ... and ${details.length - 5} more`)
+  }
+  console.log()
+}
+
+const stmtLost = (byType['STMT_COUNT_LOST']?.length ?? 0) + (byType['STMT_MISSING_IN_MERGED']?.length ?? 0)
+const fnLost   = (byType['FN_COUNT_LOST']?.length ?? 0)   + (byType['FN_MISSING_IN_MERGED']?.length ?? 0)
+const brLost   = (byType['BRANCH_COUNT_LOST']?.length ?? 0) + (byType['BRANCH_MISSING_IN_MERGED']?.length ?? 0)
+console.log(`Impact estimate: ~${stmtLost} statements, ~${fnLost} functions, ~${brLost} branch arms lost`)
+
+// ── Structure diff ────────────────────────────────────────────────────────────
+// Also show files where e2e has MORE statements than unit/comp (triggers structure switch)
+console.log('\n── STRUCTURE MISMATCH (e2e has more items than unit+comp, causes structure switch) ──')
+if (e2e) {
+  let found = 0
+  for (const file of Object.keys(e2e)) {
+    const e2eCov = e2e[file]
+    const mergedCov = merged[file]
+    if (!mergedCov) continue
+
+    const e2eStmts = Object.keys(e2eCov.statementMap || {}).length
+    const unitStmts = unit?.[file] ? Object.keys(unit[file].statementMap || {}).length : 0
+    const compStmts = comp?.[file] ? Object.keys(comp[file].statementMap || {}).length : 0
+    const maxSourceStmts = Math.max(unitStmts, compStmts)
+
+    if (e2eStmts > maxSourceStmts && maxSourceStmts > 0) {
+      found++
+      console.log(`  ${file.replace(/.*[/\\]src[/\\]/, 'src/')}`)
+      console.log(`    statements: unit=${unitStmts} comp=${compStmts} e2e=${e2eStmts} merged=${Object.keys(mergedCov.statementMap || {}).length}`)
+    }
+  }
+  if (found === 0) console.log('  None — e2e never has more items than unit/comp.')
+}

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -42,6 +42,11 @@ vi.mock('../merger/index.js', () => ({
   }),
 }))
 
+vi.mock('../merger/rebase.js', () => ({
+  rebaseCoarserMaps: (maps: unknown[]) => maps,
+  countRebasedFiles: () => 0,
+}))
+
 describe('CLI merge command', () => {
   describe('MERGE_HELP constant', () => {
     it('should contain usage information', () => {

--- a/src/__tests__/merger.test.ts
+++ b/src/__tests__/merger.test.ts
@@ -367,8 +367,9 @@ describe('CoverageMerger - fixes', () => {
 })
 
 describe('CoverageMerger - structure preference', () => {
-  it('should prefer last source structure (E2E convention)', async () => {
+  it('should prefer source with fewest zero-hit statements (fewest-zeros strategy)', async () => {
     const merger = new CoverageMerger({ applyFixes: false })
+    // map1 has 1 statement with 0 zeros; map2 has 3 statements with 1 zero
     const map1 = createTestCoverageMap({
       '/test.ts': { statements: { '0': 1 } },
     })
@@ -379,8 +380,8 @@ describe('CoverageMerger - structure preference', () => {
     const result = await merger.merge(map1, map2)
     const coverage = getFileCoverageData(result, '/test.ts')
 
-    // Should have 3 statements (more items wins by default, which is also the last source)
-    expect(Object.keys(coverage.statementMap).length).toBe(3)
+    // map1 wins (0 zeros < 1 zero) — fewest-zeros strategy picks the more fully-covered skeleton
+    expect(Object.keys(coverage.statementMap).length).toBe(1)
   })
 
   it('should prefer source with more items by default (preferUnion: true)', async () => {
@@ -399,8 +400,9 @@ describe('CoverageMerger - structure preference', () => {
     expect(Object.keys(coverage.statementMap).length).toBe(3)
   })
 
-  it('should prefer last source when preferUnion is false (strip mode)', async () => {
+  it('should still prefer fewest zeros when preferUnion is false (strip mode)', async () => {
     const merger = new CoverageMerger({ applyFixes: false, preferUnion: false })
+    // map1 has 3 fully-hit statements (0 zeros); map2 has 1 zero-hit statement
     const map1 = createTestCoverageMap({
       '/test.ts': { statements: { '0': 1, '1': 1, '2': 1 } },
     })
@@ -411,8 +413,8 @@ describe('CoverageMerger - structure preference', () => {
     const result = await merger.merge(map1, map2)
     const coverage = getFileCoverageData(result, '/test.ts')
 
-    // Should have 1 statement (last source wins when preferUnion is false)
-    expect(Object.keys(coverage.statementMap).length).toBe(1)
+    // map1 wins (0 zeros < 1 zero) — fewest-zeros applies in strip mode too
+    expect(Object.keys(coverage.statementMap).length).toBe(3)
   })
 })
 
@@ -691,9 +693,9 @@ describe('CoverageMerger - merge functions with different structures', () => {
     expect(Object.keys(coverage.fnMap).length).toBe(3)
   })
 
-  it('should prefer last source when preferUnion is false (strip mode)', async () => {
+  it('should prefer source with more hits when zeros are tied (strip mode)', async () => {
     const merger = new CoverageMerger({ applyFixes: false, preferUnion: false })
-    // map1 has more functions (3) than map2 (1)
+    // Both sources have 0 zeros; map1 has more total hits (4 vs 2) so map1 wins
     const map1 = createTestCoverageMap({
       '/test.ts': { statements: { '0': 1 }, functions: { '0': 1, '1': 1, '2': 1 } },
     })
@@ -704,8 +706,8 @@ describe('CoverageMerger - merge functions with different structures', () => {
     const result = await merger.merge(map1, map2)
     const coverage = getFileCoverageData(result, '/test.ts')
 
-    // Last source wins when preferUnion: false - should have 1 function from map2
-    expect(Object.keys(coverage.fnMap).length).toBe(1)
+    // map1 wins (tied zeros, map1 hits=4 > map2 hits=2) — should have 3 functions from map1
+    expect(Object.keys(coverage.fnMap).length).toBe(3)
   })
 
   it('should prefer source with more branches by default (preferUnion: true)', async () => {
@@ -725,9 +727,9 @@ describe('CoverageMerger - merge functions with different structures', () => {
     expect(Object.keys(coverage.branchMap).length).toBe(2)
   })
 
-  it('should prefer last source branches when preferUnion is false (strip mode)', async () => {
+  it('should prefer source with more items when zeros and hits are tied (strip mode)', async () => {
     const merger = new CoverageMerger({ applyFixes: false, preferUnion: false })
-    // map1 has more branches (2) than map2 (1)
+    // Both sources have same stmt zeros/hits; map1 has 2 branches vs map2 has 1
     const map1 = createTestCoverageMap({
       '/test.ts': { statements: { '0': 1 }, branches: { '0': [1, 0], '1': [1, 1] } },
     })
@@ -738,8 +740,8 @@ describe('CoverageMerger - merge functions with different structures', () => {
     const result = await merger.merge(map1, map2)
     const coverage = getFileCoverageData(result, '/test.ts')
 
-    // Last source wins when preferUnion: false - should have 1 branch from map2
-    expect(Object.keys(coverage.branchMap).length).toBe(1)
+    // map1 wins (tied zeros and hits, map1 totalItems=3 > map2 totalItems=2) — 2 branches from map1
+    expect(Object.keys(coverage.branchMap).length).toBe(2)
   })
 })
 

--- a/src/cli/commands/merge.ts
+++ b/src/cli/commands/merge.ts
@@ -263,9 +263,20 @@ export async function executeMerge(options: MergeOptions): Promise<MergeResult> 
       console.log(`   Stripped: ${totalImportsRemoved} imports, ${totalDirectivesRemoved} directives`)
     }
 
+    // Rebase coarser-structured maps onto the richest available structure.
+    // This corrects Turbopack E2E coverage whose statement count is lower than
+    // the Vite/esbuild-instrumented unit/component coverage for the same files.
+    // No-op for webpack/Next.js 14-15 projects where all inputs share the same structure.
+    const { rebaseCoarserMaps, countRebasedFiles } = await import('@/merger/rebase.js')
+    const rebasedMaps = rebaseCoarserMaps(coverageMaps)
+    const rebasedCount = countRebasedFiles(coverageMaps, rebasedMaps)
+    if (rebasedCount > 0) {
+      console.log(`   Rebased: ${rebasedCount} files (Turbopack → Vite structure)`)
+    }
+
     // Merge all coverage maps using the merger's merge method
     // This uses the "max" strategy with "more items wins" for structure
-    const mergedMap = await merger.merge(...coverageMaps)
+    const mergedMap = await merger.merge(...rebasedMaps)
 
     // Generate reports
     const absoluteOutput = resolve(process.cwd(), options.output)

--- a/src/collector/client.ts
+++ b/src/collector/client.ts
@@ -137,9 +137,10 @@ export class ClientCoverageCollector {
 
       // Include Next.js chunks
       if (isNextChunksUrl(normalizedUrl)) {
-        // Exclude vendor chunks (numeric prefixes like 878-xxx.js)
+        // Exclude vendor chunks with purely numeric prefixes (e.g. 878-xxx.js).
+        // Do NOT exclude hashed chunks that merely start with a digit (e.g. 02ec7w~yl_u_a.js).
         const filename = normalizedUrl.split('/').pop() || ''
-        if (/^\d+/.test(filename)) return false
+        if (/^\d+-/.test(filename)) return false
         return true
       }
 

--- a/src/converter/coverage-fixes.ts
+++ b/src/converter/coverage-fixes.ts
@@ -593,6 +593,58 @@ export function removePhantomBranches(coverageMap: CoverageMap): void {
 }
 
 /**
+ * Fix inverted source ranges produced by Turbopack's function inlining.
+ *
+ * When Turbopack (Next.js 14+ dev, Next.js 16+ production) inlines small
+ * helper functions into call sites, the resulting source map can have segments
+ * that jump backwards. The `ast-v8-to-istanbul` converter uses these segment
+ * boundaries as statement/function ranges, yielding entries where
+ * `end.line < start.line` (e.g. `L104:2 → L33:?`).
+ *
+ * `istanbul-lib-coverage` interprets these as uncovered zero-length ranges,
+ * which inflates uncovered statement counts in the HTML report. We clamp them
+ * to zero-width ranges (end = start) so they don't appear as separate uncovered
+ * statements while preserving the original hit count.
+ *
+ * Affected Next.js versions: 14+ (dev), 16+ (production Turbopack build).
+ * Not needed for Next.js 14/15 webpack production builds.
+ */
+export function fixInvertedRanges(coverageMap: CoverageMap): void {
+  type Loc = { start: { line: number; column: number | null }; end: { line: number | null; column: number | null } }
+
+  const clamp = (loc: Loc): void => {
+    if (loc.end.line !== null && loc.end.line < loc.start.line) {
+      loc.end.line = loc.start.line
+      loc.end.column = loc.start.column
+    }
+  }
+
+  for (const filePath of coverageMap.files()) {
+    const fileCoverage = coverageMap.fileCoverageFor(filePath)
+    const data = (fileCoverage as unknown as { data: CoverageMapData[string] }).data
+
+    const statementMap = data.statementMap as Record<string, Loc>
+    for (const loc of Object.values(statementMap)) {
+      clamp(loc)
+    }
+
+    const fnMap = data.fnMap as Record<string, { loc: Loc; decl?: Loc }>
+    for (const fn of Object.values(fnMap)) {
+      clamp(fn.loc)
+      if (fn.decl) clamp(fn.decl)
+    }
+
+    const branchMap = data.branchMap as Record<string, { loc?: Loc; locations?: Loc[] }>
+    for (const branch of Object.values(branchMap)) {
+      if (branch.loc) clamp(branch.loc)
+      for (const loc of branch.locations ?? []) {
+        clamp(loc)
+      }
+    }
+  }
+}
+
+/**
  * Fix function declaration statements that have 0 hits but the function has calls.
  *
  * Next.js 15 inserts TURBOPACK_DISABLE_EXPORT_MERGING comments in server actions:

--- a/src/converter/index.ts
+++ b/src/converter/index.ts
@@ -35,6 +35,7 @@ import {
   removePhantomBranches,
   fixFunctionDeclarationStatements,
   removeDuplicateFunctionEntries,
+  fixInvertedRanges,
 } from './coverage-fixes.js'
 
 // Handle ESM/CJS interop for default exports
@@ -355,6 +356,12 @@ export class CoverageConverter {
     // Remove duplicate function entries created by V8 CDP for arrow function exports
     // This fixes incorrect function coverage percentages (e.g., 4/6 = 66% instead of 3/3 = 100%)
     removeDuplicateFunctionEntries(normalizedMap)
+
+    // Fix inverted statement/function ranges produced by Turbopack's function inlining.
+    // Turbopack (Next.js 14+ dev, Next.js 16+ production) sometimes emits source map
+    // segments that jump backwards, producing ranges where end.line < start.line.
+    // Clamp these to zero-width ranges so they don't appear as phantom uncovered statements.
+    fixInvertedRanges(normalizedMap)
 
     endConvert()
     return normalizedMap

--- a/src/merger/__tests__/rebase.test.ts
+++ b/src/merger/__tests__/rebase.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'vitest'
+import libCoverage from 'istanbul-lib-coverage'
+import type { CoverageMapData } from 'istanbul-lib-coverage'
+import { rebaseCoarserMaps, countRebasedFiles } from '../rebase.js'
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function makeMap(files: Record<string, {
+  stmts: Array<{ line: number; col: number; hit: number }>
+  fns?: Array<{ line: number; col: number; hit: number }>
+  branches?: Array<{ line: number; col: number; hits: number[] }>
+}>): ReturnType<typeof libCoverage.createCoverageMap> {
+  const data: CoverageMapData = {}
+
+  for (const [file, { stmts, fns = [], branches = [] }] of Object.entries(files)) {
+    const statementMap: Record<string, unknown> = {}
+    const s: Record<string, number> = {}
+    stmts.forEach(({ line, col, hit }, i) => {
+      statementMap[String(i)] = { start: { line, column: col }, end: { line, column: col + 1 } }
+      s[String(i)] = hit
+    })
+
+    const fnMap: Record<string, unknown> = {}
+    const f: Record<string, number> = {}
+    fns.forEach(({ line, col, hit }, i) => {
+      fnMap[String(i)] = {
+        name: `fn${i}`,
+        decl: { start: { line, column: col }, end: { line, column: col + 1 } },
+        loc: { start: { line, column: col }, end: { line, column: col + 1 } },
+        line,
+      }
+      f[String(i)] = hit
+    })
+
+    const branchMap: Record<string, unknown> = {}
+    const b: Record<string, number[]> = {}
+    branches.forEach(({ line, col, hits }, i) => {
+      branchMap[String(i)] = {
+        type: 'if',
+        loc: { start: { line, column: col }, end: { line, column: col + 1 } },
+        locations: hits.map(() => ({ start: { line, column: col }, end: { line, column: col + 1 } })),
+        line,
+      }
+      b[String(i)] = hits
+    })
+
+    data[file] = { path: file, statementMap, fnMap, branchMap, s, f, b } as unknown as CoverageMapData[string]
+  }
+
+  return libCoverage.createCoverageMap(data)
+}
+
+function stmtCount(map: ReturnType<typeof libCoverage.createCoverageMap>, file: string): number {
+  return Object.keys((map.fileCoverageFor(file).toJSON() as { statementMap: Record<string, unknown> }).statementMap).length
+}
+
+function hits(map: ReturnType<typeof libCoverage.createCoverageMap>, file: string): number[] {
+  return Object.values((map.fileCoverageFor(file).toJSON() as { s: Record<string, number> }).s)
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+describe('rebaseCoarserMaps', () => {
+  it('is a no-op when all maps have identical structures', () => {
+    const unit = makeMap({ '/src/a.ts': { stmts: [{ line: 2, col: 0, hit: 1 }, { line: 3, col: 0, hit: 1 }] } })
+    const e2e  = makeMap({ '/src/a.ts': { stmts: [{ line: 2, col: 0, hit: 1 }, { line: 3, col: 0, hit: 0 }] } })
+
+    const [r0, r1] = rebaseCoarserMaps([unit, e2e])
+
+    // Same object references when no rebase needed
+    expect(stmtCount(r0, '/src/a.ts')).toBe(2)
+    expect(stmtCount(r1, '/src/a.ts')).toBe(2)
+    // hits unchanged
+    expect(hits(r1, '/src/a.ts')).toEqual([1, 0])
+  })
+
+  it('rebases a coarser E2E map onto a richer unit map', () => {
+    // unit: 3 statements at lines 2, 3, 4 — Vite granularity
+    const unit = makeMap({
+      '/src/a.ts': {
+        stmts: [
+          { line: 2, col: 0, hit: 1 },
+          { line: 3, col: 0, hit: 1 },
+          { line: 4, col: 0, hit: 1 },
+        ],
+      },
+    })
+    // e2e: only 2 statements — Turbopack merged lines 3+4 into one node at line 3
+    const e2e = makeMap({
+      '/src/a.ts': {
+        stmts: [
+          { line: 2, col: 0, hit: 5 },  // exact match with unit stmt 0
+          { line: 3, col: 0, hit: 3 },  // exact match with unit stmt 1; unit stmt 2 (line 4) has no e2e counterpart
+        ],
+      },
+    })
+
+    const [rUnit, rE2e] = rebaseCoarserMaps([unit, e2e])
+
+    // unit unchanged (already richest)
+    expect(stmtCount(rUnit, '/src/a.ts')).toBe(3)
+
+    // e2e rebased onto unit's 3-statement structure
+    expect(stmtCount(rE2e, '/src/a.ts')).toBe(3)
+
+    const e2eHits = hits(rE2e, '/src/a.ts')
+    expect(e2eHits[0]).toBe(5)  // line 2: exact match
+    expect(e2eHits[1]).toBe(3)  // line 3: exact match
+    expect(e2eHits[2]).toBe(0)  // line 4: no e2e counterpart → 0
+  })
+
+  it('uses line-number fallback when col differs', () => {
+    const unit = makeMap({
+      '/src/b.ts': {
+        stmts: [
+          { line: 5, col: 2, hit: 0 },  // Vite: col=2
+        ],
+      },
+    })
+    const e2e = makeMap({
+      '/src/b.ts': {
+        stmts: [
+          { line: 5, col: 0, hit: 7 },  // Turbopack: same line, different col
+        ],
+      },
+    })
+
+    const [, rE2e] = rebaseCoarserMaps([unit, e2e])
+
+    // e2e has same stmt count so unit is richer only by definition (mapIdx=0)
+    // but col mismatch means exact lookup fails → falls back to line lookup
+    const e2eHits = hits(rE2e, '/src/b.ts')
+    expect(e2eHits[0]).toBe(7)
+  })
+
+  it('returns single-map array unchanged', () => {
+    const unit = makeMap({ '/src/c.ts': { stmts: [{ line: 1, col: 0, hit: 2 }] } })
+    const [r] = rebaseCoarserMaps([unit])
+    expect(r).toBe(unit)
+  })
+
+  it('keeps e2e-only files (not in other maps) unchanged', () => {
+    const unit = makeMap({ '/src/a.ts': { stmts: [{ line: 2, col: 0, hit: 1 }, { line: 3, col: 0, hit: 1 }] } })
+    const e2e  = makeMap({
+      '/src/a.ts': { stmts: [{ line: 2, col: 0, hit: 1 }] },          // coarser — will be rebased
+      '/src/server.ts': { stmts: [{ line: 10, col: 0, hit: 4 }] },    // e2e-only — kept as-is
+    })
+
+    const [, rE2e] = rebaseCoarserMaps([unit, e2e])
+
+    expect(stmtCount(rE2e, '/src/a.ts')).toBe(2)          // rebased
+    expect(stmtCount(rE2e, '/src/server.ts')).toBe(1)     // unchanged
+    expect(hits(rE2e, '/src/server.ts')).toEqual([4])
+  })
+
+  it('rebases function and branch hit counts', () => {
+    const unit = makeMap({
+      '/src/d.ts': {
+        stmts: [{ line: 2, col: 0, hit: 0 }],
+        fns: [{ line: 2, col: 0, hit: 0 }],
+        branches: [{ line: 2, col: 0, hits: [0, 0] }],
+      },
+    })
+    const e2e = makeMap({
+      '/src/d.ts': {
+        stmts: [{ line: 2, col: 0, hit: 3 }],
+        fns: [{ line: 2, col: 0, hit: 3 }],
+        branches: [{ line: 2, col: 0, hits: [2, 1] }],
+      },
+    })
+
+    const [, rE2e] = rebaseCoarserMaps([unit, e2e])
+    const data = rE2e.fileCoverageFor('/src/d.ts').toJSON() as {
+      s: Record<string, number>
+      f: Record<string, number>
+      b: Record<string, number[]>
+    }
+
+    expect(data.s['0']).toBe(3)
+    expect(data.f['0']).toBe(3)
+    expect(data.b['0']).toEqual([2, 1])
+  })
+})
+
+describe('countRebasedFiles', () => {
+  it('returns 0 when no files were rebased', () => {
+    const unit = makeMap({ '/src/a.ts': { stmts: [{ line: 2, col: 0, hit: 1 }] } })
+    const e2e  = makeMap({ '/src/a.ts': { stmts: [{ line: 2, col: 0, hit: 1 }] } })
+    const rebased = rebaseCoarserMaps([unit, e2e])
+    expect(countRebasedFiles([unit, e2e], rebased)).toBe(0)
+  })
+
+  it('counts files that gained statements after rebase', () => {
+    const unit = makeMap({ '/src/a.ts': { stmts: [{ line: 2, col: 0, hit: 1 }, { line: 3, col: 0, hit: 1 }] } })
+    const e2e  = makeMap({ '/src/a.ts': { stmts: [{ line: 2, col: 0, hit: 1 }] } })
+    const rebased = rebaseCoarserMaps([unit, e2e])
+    expect(countRebasedFiles([unit, e2e], rebased)).toBe(1)
+  })
+})

--- a/src/merger/core.ts
+++ b/src/merger/core.ts
@@ -275,20 +275,26 @@ export class CoverageMerger {
   }
 
   /**
-   * Select the best source coverage for structure.
+   * Select the best source coverage structure for merging.
    *
-   * When preferUnion is true (default):
-   *   - Prefer coverage WITH MORE items (includes imports and directives)
-   *   - This gives you the union of all statement structures
+   * NOTE: Hit-count merging in mergeFileCoveragesMax() is already position-based —
+   * it uses buildLookups() which keys by `startLine:startCol`. So hits from all
+   * sources are correctly attributed regardless of which source's structure wins here.
+   * This function only determines WHICH source's statementMap/fnMap/branchMap keys
+   * (integer indices) are used as the output structure.
    *
-   * When preferUnion is false (--strip mode):
-   *   - Prefer coverage WITHOUT L1:0 directive statements (E2E-style)
-   *   - E2E coverage is more accurate because it doesn't count non-executable directives
+   * Ranking (applied in order):
+   *   1. Fewest zero-hit items — avoids phantom zero nodes from Turbopack's extra AST
+   *      entries for static/prerendered pages that were never executed at runtime.
+   *      A source that fully covers a file wins over one with phantom zero nodes.
+   *   2. Most total hits — when both sources fully cover a file, prefer the one with
+   *      more execution (e.g. Vitest ran 1000 assertions vs E2E ran 2 page loads).
+   *   3. More items — when hits are equal, prefer the more granular structure.
+   *   4. Later source — by convention E2E is passed last; for server-only files that
+   *      only E2E covers, it wins naturally (it's the only non-empty candidate).
    *
-   * Rules:
-   * 1. Filter out sources with no coverage data (0 statements AND 0 branches AND 0 functions)
-   * 2. If preferUnion: prefer source with MORE items
-   * 3. If !preferUnion: prefer source without L1:0 directives, then prefer LAST one
+   * When preferUnion is false (--strip mode), sources with L1:0 directive statements
+   * are deprioritised first, then the same ranking applies within the remaining group.
    */
   private selectBestSource(coverages: FileCoverageData[], preferUnion: boolean = true): FileCoverageData {
     // Helper to count total items (statements + branches + functions)
@@ -316,23 +322,37 @@ export class CoverageMerger {
       return nonEmptyWithIndex[0].cov
     }
 
-    // If preferUnion is true, pick the source with MORE items
-    // This includes imports and directives from vitest coverage
-    // When item counts are equal, prefer the LAST source (typically E2E with better execution counts)
-    if (preferUnion) {
-      return nonEmptyWithIndex.reduce((best, current) => {
+    // Rank candidates: fewest zeros → most hits → more items → later source
+    const rankBest = (candidates: { cov: FileCoverageData; idx: number }[]): FileCoverageData => {
+      const getZeroCount = (cov: FileCoverageData): number =>
+        Object.values(cov.s || {}).filter((v) => (v as number) === 0).length +
+        Object.values(cov.f || {}).filter((v) => (v as number) === 0).length
+
+      const getTotalHits = (cov: FileCoverageData): number =>
+        Object.values(cov.s || {}).reduce((sum: number, v) => sum + (v as number), 0) +
+        Object.values(cov.f || {}).reduce((sum: number, v) => sum + (v as number), 0)
+
+      return candidates.reduce((best, current) => {
+        const currentZeros = getZeroCount(current.cov)
+        const bestZeros = getZeroCount(best.cov)
+        if (currentZeros < bestZeros) return current
+        if (currentZeros > bestZeros) return best
+        const currentHits = getTotalHits(current.cov)
+        const bestHits = getTotalHits(best.cov)
+        if (currentHits > bestHits) return current
+        if (currentHits < bestHits) return best
         const currentItems = getTotalItems(current.cov)
         const bestItems = getTotalItems(best.cov)
-        // Prefer more items, or if equal, prefer later source (higher index)
-        if (currentItems > bestItems || (currentItems === bestItems && current.idx > best.idx)) {
-          return current
-        }
+        if (currentItems > bestItems || (currentItems === bestItems && current.idx > best.idx)) return current
         return best
       }).cov
     }
 
-    // preferUnion is false (--strip mode): prefer E2E-style without directives
-    // Check which coverages have L1:0 directive statements
+    if (preferUnion) {
+      return rankBest(nonEmptyWithIndex)
+    }
+
+    // preferUnion is false (--strip mode): deprioritise sources with L1:0 directive statements
     const withDirective: { cov: FileCoverageData; idx: number }[] = []
     const withoutDirective: { cov: FileCoverageData; idx: number }[] = []
 
@@ -350,20 +370,12 @@ export class CoverageMerger {
       }
     }
 
-    // Prefer coverage without directive (E2E-style)
     if (withoutDirective.length > 0) {
-      // Among sources without directives, prefer the LAST one in the original array
-      // By convention, E2E is passed last when merging
-      const lastItem = withoutDirective.reduce((best, current) =>
-        current.idx > best.idx ? current : best
-      )
-      return lastItem.cov
+      return rankBest(withoutDirective)
     }
 
-    // All non-empty sources have directives - pick the one with fewer items (less directive inflation)
-    return nonEmptyWithIndex.reduce((best, current) =>
-      getTotalItems(current.cov) < getTotalItems(best.cov) ? current : best
-    ).cov
+    // All non-empty sources have directives - apply same ranking
+    return rankBest(nonEmptyWithIndex)
   }
 
   /**

--- a/src/merger/rebase.ts
+++ b/src/merger/rebase.ts
@@ -1,0 +1,157 @@
+/**
+ * Coverage Structure Rebasing
+ *
+ * When merging Vitest (unit/component) coverage with E2E (Playwright/Next.js)
+ * coverage, the two sets may have different Istanbul structures for the same
+ * source file. This happens because:
+ *
+ *   - Vitest uses Vite/esbuild, which preserves full source AST granularity
+ *   - Next.js 16+ Turbopack production builds scope-hoist and minify, collapsing
+ *     multiple AST nodes into single compiled nodes. V8 coverage only sees one
+ *     byte-offset range per compiled node, so `ast-v8-to-istanbul` produces
+ *     fewer Istanbul statements for the same source file.
+ *
+ * Result: Turbopack E2E coverage appears inflated (e.g. 55%) because its
+ * denominator is smaller (1315 statements) vs the source-accurate count (1771).
+ *
+ * Fix: Before merging, rebase every coverage map whose per-file statement count
+ * is lower than the richest available map for that file. "Rebase" means:
+ *   1. Take the richest map's statementMap/fnMap/branchMap as the structure
+ *   2. Look up hit counts from the coarser map by line:col (exact) or line (fallback)
+ *   3. Overwrite the coarser map's entries with the rebased data
+ *
+ * This is a no-op for webpack/Next.js 14-15 projects where all inputs already
+ * share the same Vite/esbuild structure.
+ */
+
+import libCoverage from 'istanbul-lib-coverage'
+import type { CoverageMap, FileCoverageData } from 'istanbul-lib-coverage'
+import { locationKey, lineKey, buildLookups } from './utils.js'
+import type { Location, FnEntry, BranchEntry } from './utils.js'
+
+/**
+ * Rebase coarser-structured coverage maps onto the richest available structure.
+ *
+ * For each file present in multiple maps, the map with the most statements is
+ * used as the structure skeleton. All other maps for that file are rebased: their
+ * hit counts are remapped by line:col position onto the richer skeleton.
+ *
+ * Maps that only contain files not present in any other map are returned unchanged.
+ *
+ * @param maps - Array of CoverageMap instances (unit, component, e2e, ...)
+ * @returns New array of CoverageMap instances with rebased structures
+ */
+export function rebaseCoarserMaps(maps: CoverageMap[]): CoverageMap[] {
+  if (maps.length < 2) return maps
+
+  // Collect all file paths across all maps
+  const allFiles = new Set<string>()
+  for (const map of maps) {
+    for (const file of map.files()) {
+      allFiles.add(file)
+    }
+  }
+
+  // For each file, find the richest structure (most statements)
+  const richestByFile = new Map<string, { stmtCount: number; mapIdx: number; data: FileCoverageData }>()
+
+  for (let i = 0; i < maps.length; i++) {
+    for (const file of maps[i].files()) {
+      const data = maps[i].fileCoverageFor(file).toJSON() as FileCoverageData
+      const stmtCount = Object.keys(data.statementMap || {}).length
+      const current = richestByFile.get(file)
+      if (!current || stmtCount > current.stmtCount) {
+        richestByFile.set(file, { stmtCount, mapIdx: i, data })
+      }
+    }
+  }
+
+  // Rebase each map: for files where a richer structure exists in another map,
+  // remap this map's hit counts onto the richer skeleton
+  return maps.map((map, mapIdx) => {
+    const newMapData: Record<string, FileCoverageData> = {}
+    let rebased = 0
+
+    for (const file of map.files()) {
+      const richest = richestByFile.get(file)!
+      const thisData = map.fileCoverageFor(file).toJSON() as FileCoverageData
+      const thisStmtCount = Object.keys(thisData.statementMap || {}).length
+
+      // If this map already has the richest structure for this file, keep as-is
+      if (richest.mapIdx === mapIdx || thisStmtCount >= richest.stmtCount) {
+        newMapData[file] = thisData
+        continue
+      }
+
+      // Build position→hits lookups from this map's (coarser) data
+      const lookups = buildLookups(thisData)
+
+      // Build a new coverage entry using the richest statementMap/fnMap/branchMap
+      // but with hit counts resolved from this map's positions
+      const rebased_s: Record<string, number> = {}
+      for (const [key, loc] of Object.entries(richest.data.statementMap || {}) as [string, Location][]) {
+        const exact = lookups.stmts.get(locationKey(loc))
+        if (exact !== undefined) {
+          rebased_s[key] = exact
+        } else {
+          rebased_s[key] = lookups.stmtsByLine.get(lineKey(loc)) ?? 0
+        }
+      }
+
+      const rebased_f: Record<string, number> = {}
+      for (const [key, fn] of Object.entries(richest.data.fnMap || {}) as [string, FnEntry][]) {
+        const exact = lookups.fns.get(locationKey(fn.loc))
+        if (exact !== undefined) {
+          rebased_f[key] = exact
+        } else {
+          rebased_f[key] = lookups.fnsByLine.get(lineKey(fn.loc)) ?? 0
+        }
+      }
+
+      const rebased_b: Record<string, number[]> = {}
+      for (const [key, branch] of Object.entries(richest.data.branchMap || {}) as [string, BranchEntry][]) {
+        const exact = lookups.branches.get(locationKey(branch.loc))
+        if (exact !== undefined) {
+          rebased_b[key] = exact
+        } else {
+          const byLine = lookups.branchesByLine.get(lineKey(branch.loc))
+          rebased_b[key] = byLine ?? new Array((branch as unknown as { locations: unknown[] }).locations?.length ?? 2).fill(0)
+        }
+      }
+
+      newMapData[file] = {
+        ...thisData,
+        statementMap: richest.data.statementMap,
+        fnMap: richest.data.fnMap,
+        branchMap: richest.data.branchMap,
+        s: rebased_s,
+        f: rebased_f,
+        b: rebased_b,
+      }
+      rebased++
+    }
+
+    if (rebased === 0) return map
+
+    return libCoverage.createCoverageMap(newMapData as unknown as Parameters<typeof libCoverage.createCoverageMap>[0])
+  })
+}
+
+/**
+ * Count how many files were rebased across all maps (for diagnostics).
+ */
+export function countRebasedFiles(original: CoverageMap[], rebased: CoverageMap[]): number {
+  let count = 0
+  for (let i = 0; i < original.length; i++) {
+    for (const file of original[i].files()) {
+      const origStmts = Object.keys(
+        (original[i].fileCoverageFor(file).toJSON() as FileCoverageData).statementMap || {}
+      ).length
+      const newStmts = Object.keys(
+        (rebased[i].fileCoverageFor(file).toJSON() as FileCoverageData).statementMap || {}
+      ).length
+      if (newStmts > origStmts) count++
+    }
+  }
+  return count
+}

--- a/src/parsers/__tests__/webpack.test.ts
+++ b/src/parsers/__tests__/webpack.test.ts
@@ -61,6 +61,20 @@ describe('webpack parser', () => {
     it('should handle combined transformations', () => {
       expect(normalizeWebpackSourcePath('webpack://_N_E/./src/app/page.tsx?xxxx')).toBe('src/app/page.tsx')
     })
+
+    it('should strip turbopack:///[project]/ prefix (Next.js 14+ dev, Next.js 16+ production)', () => {
+      expect(normalizeWebpackSourcePath('turbopack:///[project]/src/app/page.tsx')).toBe('src/app/page.tsx')
+      expect(normalizeWebpackSourcePath('turbopack:///[project]/src/components/Button.tsx')).toBe('src/components/Button.tsx')
+      expect(normalizeWebpackSourcePath('turbopack:///[project]/src/lib/utils.ts')).toBe('src/lib/utils.ts')
+    })
+
+    it('should strip turbopack:///[root-of-the-server]/ prefix', () => {
+      expect(normalizeWebpackSourcePath('turbopack:///[root-of-the-server]/src/app/layout.tsx')).toBe('src/app/layout.tsx')
+    })
+
+    it('should strip any turbopack:/// virtual segment prefix', () => {
+      expect(normalizeWebpackSourcePath('turbopack:///[turbopack-node]/src/utils.ts')).toBe('src/utils.ts')
+    })
   })
 
   describe('extractWebpackModulePath', () => {

--- a/src/parsers/webpack.ts
+++ b/src/parsers/webpack.ts
@@ -37,15 +37,33 @@ export const WEBPACK_PREFIX_PATTERN = /^webpack:\/\/[^/]*\//
 export const WEBPACK_INTERNAL_MODULE_PATTERN = /webpack-internal:\/\/\/\([^)]+\)\/(.+)/
 
 /**
- * Normalize a webpack source path to a relative path.
- * Handles webpack:// prefixes, _N_E/ prefixes, query strings, and leading ./
+ * Normalize a webpack or turbopack source path to a relative path.
+ * Handles webpack:// prefixes, turbopack:/// prefixes, _N_E/ prefixes,
+ * query strings, and leading ./
+ *
+ * Supports:
+ * - Next.js 14/15 webpack production: `webpack://_N_E/./src/app/page.tsx`
+ * - Next.js 14/15/16 turbopack dev:   `turbopack:///[project]/src/app/page.tsx`
+ * - Next.js 16 turbopack production:   `turbopack:///[project]/src/app/page.tsx`
  *
  * @example
  * normalizeWebpackSourcePath('webpack://_N_E/./src/app/page.tsx?xxxx')
  * // Returns: 'src/app/page.tsx'
+ * normalizeWebpackSourcePath('turbopack:///[project]/src/app/page.tsx')
+ * // Returns: 'src/app/page.tsx'
  */
 export function normalizeWebpackSourcePath(sourcePath: string): string {
   let path = sourcePath
+
+  // Remove turbopack:// prefix (Next.js 14+ dev mode and Next.js 16+ production).
+  // Turbopack uses virtual path segments in brackets: [project], [root-of-the-server], etc.
+  // e.g. turbopack:///[project]/src/app/page.tsx   → src/app/page.tsx
+  //      turbopack:///[root-of-the-server]/src/... → src/...
+  if (path.startsWith('turbopack:///')) {
+    path = path.slice('turbopack:///'.length)
+    // Strip the leading virtual segment like [project]/, [root-of-the-server]/, etc.
+    path = path.replace(/^\[[^\]]+\]\//, '')
+  }
 
   // Remove webpack:// prefix (e.g., webpack://_N_E/, webpack://app/)
   path = path.replace(WEBPACK_PREFIX_PATTERN, '')


### PR DESCRIPTION
## Summary

- **Next.js 16 Turbopack support** — handle `turbopack:///[project]/...` and `turbopack:///[root-of-the-server]/...` URL schemes for coverage collection and source map path normalization
- **Automatic E2E coverage structure rebase** — before merging, coarser Turbopack E2E maps are rebased onto the richer Vitest/unit structure, restoring accurate denominators and fixing inflated E2E-only percentages (e.g. 55% → 37%)
- **Fewest-zeros merge strategy** — `selectBestSource` now ranks by fewest zero-hit statements first, ensuring the Vitest-instrumented skeleton is always preferred over Turbopack's coarser compiled structure
- **Inverted source-map range fix** — Turbopack function inlining can produce backwards source map segments (`end.line < start.line`); these are now clamped to zero-width to eliminate phantom uncovered statements
- **Hashed chunk filter fix** — regex tightened from `/^\d+/` to `/^\d+-/` so Turbopack content-hashed chunks (e.g. `02ec7w~yl_u_a.js`) are no longer incorrectly excluded as vendor chunks
- **Upgrade `ast-v8-to-istanbul`** `^0.3.10` → `^1.0.4` for better source map mismatch handling and statement ID alignment with `@vitest/coverage-v8`
- **Upgrade `vitest` and `@vitest/coverage-v8`** `^4.0.15` → `^4.1.9`
- **Add `scripts/diagnose-merge.mjs`** — diagnostic tool to identify coverage lost during merge across unit/component/e2e sources

## Test plan

- [ ] Verify merged coverage is ≥ 100% when unit+component individually report 100% (regression: was 98.7%)
- [ ] Confirm Turbopack content-hashed chunks (e.g. `02ec7w~yl_u_a.js`) are included in client coverage
- [ ] Run `node scripts/diagnose-merge.mjs --unit <unit.json> --comp <comp.json> --e2e <e2e.json> --merged <merged.json>` to confirm no regressions in merged output
- [ ] Verify Next.js 16 Turbopack production builds produce correct coverage reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)