### PR TITLE
fix: bump engines.node to >=20.19.0 for vite 8 compatibility (v1.4.1)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+      production-dependencies:
+        dependency-type: "production"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.1] - 2026-06-29
+
+### Fixed
+
+- **Vite 8 Node.js engine requirement** - Updated `engines.node` from `>=20.0.0` to `>=20.19.0` to reflect the actual minimum required by the vite 8 dependency (`^20.19.0 || >=22.12.0`).
+
+### Changed
+
+- **Upgrade vite** `^6.0.0` → `^8.1.0` to address security vulnerabilities in vite 6's dependency tree.
+
+- **Enable Dependabot** for weekly npm dependency update PRs, grouped into production and dev dependency batches.
+
 ## [1.4.0] - 2026-06-29
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextcov",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nextcov",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.24.0",
@@ -48,7 +48,7 @@
         "vitest": "^4.1.9"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
         "@playwright/test": "^1.40.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcov",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Collect test coverage for Playwright E2E tests in Next.js applications",
   "author": "Steve Zhang",
   "license": "MIT",
@@ -49,7 +49,7 @@
     "vitest"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.19.0"
   },
   "peerDependencies": {
     "@playwright/test": "^1.40.0"


### PR DESCRIPTION
## Summary

Follow-up to #58 (vite ^8.1.0 upgrade).

Vite 8 requires `node: "^20.19.0 || >=22.12.0"`. The previous `engines.node` of `">=20.0.0"` was misleading — users on Node 20.0.0–20.18.x would get install errors from vite 8's transitive dependencies.

- Update `engines.node` from `">=20.0.0"` to `">=20.19.0"`
- Bump version to `1.4.1`

## Test plan

- [ ] Verify `npm install` fails clearly on Node <20.19.0
- [ ] Verify `npm install` succeeds on Node 20.19.0+ and 22.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)