### PR TITLE
feat: rebase E2E coverage onto source AST structure for accurate reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.2] - 2026-06-30
+
+### Added
+
+- **E2E coverage rebase onto source AST structure** - `processAllCoverage` now rebases E2E coverage onto the correct source statement structure before writing reports, when `sourceRoot` is configured. All source files are compiled through the same esbuild pipeline as Vitest (`transformWithEsbuild` + `parseAstAsync`), producing a zero-count Istanbul map whose `line:col` positions are identical to unit/component coverage. Turbopack-coarsened E2E hit counts are remapped onto this richer structure, and files the browser never loaded appear with zero counts. E2E-only reports show accurate percentages without requiring a `nextcov merge` step. When `nextcov merge` runs afterwards, the structures already match — no fallback, no misattribution. Requires `sourceRoot` to be configured.
+
+- **`workers` option for `PlaywrightCoverageOptions`** - Control worker thread count directly from the `finalizeCoverage` config instead of relying on the `NEXTCOV_WORKERS` environment variable. Set `workers: 0` for single-threaded mode. On Windows, spawning Vite's WASM-based parser in worker threads while Playwright's Chromium process is shutting down can cause heap corruption (`0xC0000374`); `workers: 0` in the globalTeardown config prevents this cleanly.
+
+- **`rebaseOntoMap` in `src/merger/rebase.ts`** - New function for rebasing coverage onto an authoritative structure skeleton. Unlike `rebaseCoarserMaps` (which picks the skeleton heuristically), `rebaseOntoMap` always uses the caller-supplied `structure` map as the skeleton, remapping `source` hit counts by exact `line:col` position with `line`-only fallback. Branch arm arrays are normalised to the skeleton's `locations.length` to prevent denominator inflation from Turbopack's differently-shaped branch nodes. Files only in `source` (outside the include patterns) are excluded; files only in `structure` retain zero counts.
+
+### Fixed
+
+- **Branch denominator inflation after rebase** - When a branch was matched only by line (fallback), the E2E source's arm array was assigned directly. If Turbopack collapsed a ternary chain into a different number of arms than the zero-map branch, this inflated the total branch count (e.g. 1249 instead of 1230). Both exact and line-fallback matches are now truncated/padded to the zero-map branch's `locations.length`.
+
+- **Worker pool infinite crash loop** - A worker that repeatedly crashed (e.g. Vite's WASM parser failing to load in a worker thread context) would be endlessly re-queued. Added `MAX_TASK_RETRIES = 2`: after two retries on fresh workers the task falls back to `runTaskDirect` (single-threaded execution in the main thread) so the promise always resolves.
+
+- **`ERR_INPUT_TYPE_NOT_ALLOWED` in worker threads** - Worker threads inherited the `--input-type=module` flag from a parent process started with `node --input-type=module`. Node.js does not allow this flag in worker threads. It is now stripped from `execArgv` before spawning.
+
+- **`isBabelQuality` heuristic removed from `rebaseCoarserMaps`** - esbuild produces `end.column: Infinity` which `JSON.stringify` serialises to `null` — identical to Turbopack's `null end.column` after a `coverage-final.json` round-trip. The heuristic was silently selecting Turbopack's coarser structure as the skeleton for some files, causing merged coverage to fall below 100%. Reverted to simple "most statements wins". Safe because E2E coverage is pre-rebased onto the esbuild structure before `nextcov merge` reads it.
+
+- **Logging not initialised in direct `finalizeCoverage` calls** - When `finalizeCoverage` is called directly in `globalTeardown` without a prior `startServerCoverage` call, `setLogging` and `setTiming` were never called. Log and timing options from the config are now applied at the start of `finalizeCoverage`.
+
+- **Empty catch block in `InProcessV8Collector`** - Silenced an ESLint `no-empty` error on the source-read catch path in `src/collector/in-process.ts`.
+
 ## [1.4.1] - 2026-06-29
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextcov",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nextcov",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.24.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcov",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Collect test coverage for Playwright E2E tests in Next.js applications",
   "author": "Steve Zhang",
   "license": "MIT",

--- a/src/__tests__/converter.test.ts
+++ b/src/__tests__/converter.test.ts
@@ -922,51 +922,103 @@ describe('CoverageConverter', () => {
   })
 
   describe('createEmptyCoverage', () => {
-    it('should return null for invalid TypeScript', async () => {
+    let emptyDir: string
+    let emptyLoader: SourceMapLoader
+    let emptyConverter: CoverageConverter
+
+    beforeEach(async () => {
+      emptyDir = join(tmpdir(), `empty-cov-${Date.now()}`)
+      await fs.mkdir(join(emptyDir, 'src'), { recursive: true })
+      emptyLoader = new SourceMapLoader(emptyDir)
+      emptyConverter = new CoverageConverter(emptyDir, emptyLoader)
+    })
+
+    afterEach(async () => {
+      try {
+        await fs.rm(emptyDir, { recursive: true, force: true })
+      } catch { /* ignore */ }
+    })
+
+    it('produces zero-count coverage for a simple TypeScript file', async () => {
+      const filePath = join(emptyDir, 'src', 'simple.ts')
+      await fs.writeFile(filePath, 'export const x = 1\nexport const y = 2\n')
+
+      const result = await emptyConverter['createEmptyCoverage'](filePath, await fs.readFile(filePath, 'utf-8'))
+
+      expect(result).not.toBeNull()
+      const fc = result![filePath] as { statementMap: Record<string, unknown>; s: Record<string, number>; path: string }
+      expect(Object.keys(fc.statementMap).length).toBeGreaterThan(0)
+      expect(Object.values(fc.s).every(v => v === 0)).toBe(true)
+      expect(fc.path).toBe(filePath)
+    })
+
+    it('produces zero-count coverage for a TypeScript file with a function', async () => {
+      const filePath = join(emptyDir, 'src', 'fn.ts')
+      await fs.writeFile(filePath, [
+        'export function add(a: number, b: number): number {',
+        '  return a + b',
+        '}',
+      ].join('\n'))
+
+      const result = await emptyConverter['createEmptyCoverage'](filePath, await fs.readFile(filePath, 'utf-8'))
+
+      expect(result).not.toBeNull()
+      const fc = result![filePath] as {
+        statementMap: Record<string, unknown>
+        fnMap: Record<string, unknown>
+        s: Record<string, number>
+        f: Record<string, number>
+      }
+      // Function should be tracked
+      expect(Object.keys(fc.fnMap).length).toBeGreaterThan(0)
+      expect(Object.values(fc.f).every(v => v === 0)).toBe(true)
+      // All hits zero
+      expect(Object.values(fc.s).every(v => v === 0)).toBe(true)
+    })
+
+    it('produces zero-count coverage for a TSX file with JSX', async () => {
+      const filePath = join(emptyDir, 'src', 'Button.tsx')
+      await fs.writeFile(filePath, [
+        'export function Button({ label }: { label: string }) {',
+        '  return <button>{label}</button>',
+        '}',
+      ].join('\n'))
+
+      const result = await emptyConverter['createEmptyCoverage'](filePath, await fs.readFile(filePath, 'utf-8'))
+
+      expect(result).not.toBeNull()
+      const fc = result![filePath] as { statementMap: Record<string, unknown>; s: Record<string, number> }
+      expect(Object.keys(fc.statementMap).length).toBeGreaterThan(0)
+      expect(Object.values(fc.s).every(v => v === 0)).toBe(true)
+    })
+
+    it('returns null gracefully for unparseable code', async () => {
       const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const filePath = join(emptyDir, 'src', 'broken.ts')
 
-      const result = await converter['createEmptyCoverage'](
-        '/project/src/invalid.ts',
-        'this is not valid { typescript ['
-      )
+      // esbuild will fail on severely broken syntax
+      const result = await emptyConverter['createEmptyCoverage'](filePath, '!!!@@@###$$$')
 
-      // May or may not be null depending on error recovery
+      // Should return null without throwing
       expect(result === null || typeof result === 'object').toBe(true)
       consoleSpy.mockRestore()
     })
 
-    it('should attempt to create coverage for TypeScript file', async () => {
-      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    it('produces more statements than a coarse 1-statement representation', async () => {
+      const filePath = join(emptyDir, 'src', 'multi.ts')
+      await fs.writeFile(filePath, [
+        'export const a = 1',
+        'export const b = 2',
+        'export const c = 3',
+        'export const d = 4',
+      ].join('\n'))
 
-      // The function may return null if ast-v8-to-istanbul fails with the file URL
-      // We're just testing that it doesn't throw
-      const result = await converter['createEmptyCoverage'](
-        '/project/src/valid.ts',
-        'export const x = 1'
-      )
+      const result = await emptyConverter['createEmptyCoverage'](filePath, await fs.readFile(filePath, 'utf-8'))
 
-      // Result may be null or object depending on environment
-      expect(result === null || typeof result === 'object').toBe(true)
-      consoleSpy.mockRestore()
-    })
-
-    it('should attempt to handle JSX files', async () => {
-      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-      const jsxCode = `
-        export function Component() {
-          return <div>Hello</div>
-        }
-      `
-
-      // The function may return null if ast-v8-to-istanbul fails
-      const result = await converter['createEmptyCoverage'](
-        '/project/src/Component.tsx',
-        jsxCode
-      )
-
-      // Result may be null or object depending on environment
-      expect(result === null || typeof result === 'object').toBe(true)
-      consoleSpy.mockRestore()
+      expect(result).not.toBeNull()
+      const fc = result![filePath] as { statementMap: Record<string, unknown> }
+      // Must see multiple statements (not collapsed into 1 like Turbopack would)
+      expect(Object.keys(fc.statementMap).length).toBeGreaterThan(1)
     })
   })
 
@@ -1289,17 +1341,21 @@ describe('CoverageConverter', () => {
       }
     })
 
-    it('should add uncovered file to coverage map', async () => {
+    it('should add uncovered file to coverage map with zero hit counts', async () => {
       const testFile = join(testDir, 'src', 'uncovered.ts')
-      await fs.writeFile(testFile, 'export const uncovered = true')
+      await fs.writeFile(testFile, 'export function foo() { return 42 }\nexport const bar = 1\n')
 
       const libCoverage = require('istanbul-lib-coverage')
       const coverageMap = libCoverage.createCoverageMap({})
 
       await testConverter.addUncoveredFiles(coverageMap, [testFile])
 
-      // May or may not add file depending on ast-v8-to-istanbul behavior
-      expect(coverageMap.files().length >= 0).toBe(true)
+      expect(coverageMap.files().length).toBe(1)
+      const fc = coverageMap.fileCoverageFor(testFile).toJSON()
+      // statementMap populated (esbuild parsed the source)
+      expect(Object.keys(fc.statementMap).length).toBeGreaterThan(0)
+      // all hits are zero
+      expect(Object.values(fc.s as Record<string, number>).every(v => v === 0)).toBe(true)
     })
 
     it('should skip files already in coverage', async () => {

--- a/src/__tests__/processor.test.ts
+++ b/src/__tests__/processor.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { promises as fs } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import libCoverage from 'istanbul-lib-coverage'
 import { CoverageProcessor } from '../core/processor.js'
 
 const isWindows = process.platform === 'win32'
@@ -135,21 +136,182 @@ describe('CoverageProcessor', () => {
     })
   })
 
-  describe('addUncoveredFiles', () => {
-    it('should add uncovered files when sourceRoot is configured', async () => {
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  describe('rebaseOntoSourceStructure', () => {
+    let rebaseTestDir: string
+    let rebaseProcessor: CoverageProcessor
 
-      const processorWithSource = new CoverageProcessor(projectRoot, {
-        outputDir: testOutputDir,
+    beforeEach(async () => {
+      rebaseTestDir = join(tmpdir(), `rebase-test-${Date.now()}`)
+      await fs.mkdir(join(rebaseTestDir, 'src'), { recursive: true })
+
+      rebaseProcessor = new CoverageProcessor(rebaseTestDir, {
+        outputDir: join(rebaseTestDir, 'coverage'),
         sourceRoot: './src',
         include: ['src/**/*.ts'],
-        reporters: ['json'], // Avoid text-summary console output during tests
+        reporters: ['json'],
+      })
+    })
+
+    afterEach(async () => {
+      try {
+        await fs.rm(rebaseTestDir, { recursive: true, force: true })
+      } catch { /* ignore */ }
+    })
+
+    it('skips rebase when sourceRoot is not configured', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const noSourceProcessor = new CoverageProcessor(rebaseTestDir, {
+        outputDir: join(rebaseTestDir, 'coverage'),
+        reporters: ['json'],
       })
 
-      // This tests the addUncoveredFiles path
-      const result = await processorWithSource.processAllCoverage()
+      const addUncoveredSpy = vi.spyOn(noSourceProcessor['converter'], 'addUncoveredFiles')
 
-      expect(result.coverageMap).toBeDefined()
+      const emptyMap = libCoverage.createCoverageMap({})
+      vi.spyOn(noSourceProcessor['reporter'], 'mergeCoverageMaps').mockResolvedValue(emptyMap)
+      vi.spyOn(noSourceProcessor['reporter'], 'generateReports').mockResolvedValue({
+        statements: { total: 0, covered: 0, pct: 100 },
+        branches: { total: 0, covered: 0, pct: 100 },
+        functions: { total: 0, covered: 0, pct: 100 },
+        lines: { total: 0, covered: 0, pct: 100 },
+      })
+
+      await noSourceProcessor.processAllCoverage()
+
+      expect(addUncoveredSpy).not.toHaveBeenCalled()
+      consoleSpy.mockRestore()
+    })
+
+    it('adds uncovered source files with zero hit counts', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      // Source file that E2E never loaded
+      await fs.writeFile(
+        join(rebaseTestDir, 'src', 'util.ts'),
+        'export function add(a: number, b: number) { return a + b }\n'
+      )
+
+      // Empty E2E coverage map — browser never loaded util.ts
+      const emptyE2e = libCoverage.createCoverageMap({})
+      // mockResolvedValueOnce: only the first call (injecting E2E) is mocked;
+      // the second call inside rebaseOntoSourceStructure uses the real merge.
+      vi.spyOn(rebaseProcessor['reporter'], 'mergeCoverageMaps').mockResolvedValueOnce(emptyE2e)
+      vi.spyOn(rebaseProcessor['reporter'], 'generateReports').mockResolvedValue({
+        statements: { total: 1, covered: 0, pct: 0 },
+        branches: { total: 0, covered: 0, pct: 100 },
+        functions: { total: 1, covered: 0, pct: 0 },
+        lines: { total: 1, covered: 0, pct: 0 },
+      })
+
+      const result = await rebaseProcessor.processAllCoverage()
+
+      // util.ts should appear with zero counts (correct denominator)
+      const files = result.coverageMap.files()
+      const utilFile = files.find(f => f.includes('util.ts'))
+      expect(utilFile).toBeDefined()
+
+      const fc = result.coverageMap.fileCoverageFor(utilFile!).toJSON() as {
+        statementMap: Record<string, unknown>
+        s: Record<string, number>
+      }
+      expect(Object.keys(fc.statementMap).length).toBeGreaterThan(0)
+      expect(Object.values(fc.s).every(v => v === 0)).toBe(true)
+      consoleSpy.mockRestore()
+    })
+
+    it('rebases coarse E2E coverage onto richer esbuild structure', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      const srcFile = join(rebaseTestDir, 'src', 'service.ts')
+      await fs.writeFile(srcFile, [
+        'export function double(n: number) { return n * 2 }',
+        'export function triple(n: number) { return n * 3 }',
+        'export function square(n: number) { return n * n }',
+      ].join('\n'))
+
+      // Coarse E2E coverage: Turbopack collapsed everything into 1 statement.
+      // Real Turbopack output has null end.column (coarser nodes), which is how
+      // isBabelQuality() distinguishes it from esbuild/Vitest-quality maps.
+      const coarseMap = libCoverage.createCoverageMap({
+        [srcFile]: {
+          path: srcFile,
+          statementMap: {
+            '0': { start: { line: 1, column: 0 }, end: { line: 1, column: null } },
+          },
+          fnMap: {},
+          branchMap: {},
+          s: { '0': 7 },
+          f: {},
+          b: {},
+        } as never,
+      })
+
+      vi.spyOn(rebaseProcessor['reporter'], 'mergeCoverageMaps').mockResolvedValueOnce(coarseMap)
+      vi.spyOn(rebaseProcessor['reporter'], 'generateReports').mockResolvedValue({
+        statements: { total: 3, covered: 1, pct: 33 },
+        branches: { total: 0, covered: 0, pct: 100 },
+        functions: { total: 3, covered: 1, pct: 33 },
+        lines: { total: 3, covered: 1, pct: 33 },
+      })
+
+      const result = await rebaseProcessor.processAllCoverage()
+
+      const files = result.coverageMap.files()
+      const serviceFile = files.find(f => f.includes('service.ts'))
+      expect(serviceFile).toBeDefined()
+
+      const fc = result.coverageMap.fileCoverageFor(serviceFile!).toJSON() as {
+        statementMap: Record<string, unknown>
+        s: Record<string, number>
+      }
+
+      // Rebased map must have MORE statements than the coarse 1-statement input
+      expect(Object.keys(fc.statementMap).length).toBeGreaterThan(1)
+      consoleSpy.mockRestore()
+    })
+
+    it('preserves hit counts after rebase', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      const srcFile = join(rebaseTestDir, 'src', 'math.ts')
+      await fs.writeFile(srcFile, 'export const PI = 3.14\nexport const E = 2.71\n')
+
+      // E2E coverage with a hit on line 1 — null end.column reflects real Turbopack output
+      const e2eMap = libCoverage.createCoverageMap({
+        [srcFile]: {
+          path: srcFile,
+          statementMap: {
+            '0': { start: { line: 1, column: 0 }, end: { line: 1, column: null } },
+          },
+          fnMap: {},
+          branchMap: {},
+          s: { '0': 3 },
+          f: {},
+          b: {},
+        } as never,
+      })
+
+      vi.spyOn(rebaseProcessor['reporter'], 'mergeCoverageMaps').mockResolvedValueOnce(e2eMap)
+      vi.spyOn(rebaseProcessor['reporter'], 'generateReports').mockResolvedValue({
+        statements: { total: 2, covered: 1, pct: 50 },
+        branches: { total: 0, covered: 0, pct: 100 },
+        functions: { total: 0, covered: 0, pct: 100 },
+        lines: { total: 2, covered: 1, pct: 50 },
+      })
+
+      const result = await rebaseProcessor.processAllCoverage()
+
+      const files = result.coverageMap.files()
+      const mathFile = files.find(f => f.includes('math.ts'))
+      expect(mathFile).toBeDefined()
+
+      const fc = result.coverageMap.fileCoverageFor(mathFile!).toJSON() as {
+        s: Record<string, number>
+      }
+
+      // At least one statement must have a non-zero hit count (the E2E hit preserved)
+      const totalHits = Object.values(fc.s).reduce((sum, v) => sum + v, 0)
+      expect(totalHits).toBeGreaterThan(0)
       consoleSpy.mockRestore()
     })
   })

--- a/src/collector/in-process.ts
+++ b/src/collector/in-process.ts
@@ -81,7 +81,7 @@ export class InProcessV8Collector {
       let source: string | undefined
       const filePath = this._urlToPath(script.url)
       if (filePath && existsSync(filePath)) {
-        try { source = readFileSync(filePath, 'utf-8') } catch {}
+        try { source = readFileSync(filePath, 'utf-8') } catch (_e) { /* file unreadable, skip */ }
       }
 
       entries.push({

--- a/src/converter/index.ts
+++ b/src/converter/index.ts
@@ -7,8 +7,7 @@
 
 import { existsSync } from 'node:fs'
 import { resolve, sep } from 'node:path'
-import { parse as babelParse } from '@babel/parser'
-import { parseAstAsync } from 'vite'
+import { parseAstAsync, transformWithEsbuild } from 'vite'
 import _astV8ToIstanbul from 'ast-v8-to-istanbul'
 import libCoverage from 'istanbul-lib-coverage'
 import libSourceMaps from 'istanbul-lib-source-maps'
@@ -954,41 +953,69 @@ export class CoverageConverter {
   }
 
   /**
-   * Create empty coverage entry for an uncovered file
-   * Uses Babel parser to properly parse TypeScript/TSX and extract functions/branches.
+   * Create empty coverage entry for an uncovered file.
+   *
+   * Uses the same esbuild pipeline as Vitest: transformWithEsbuild compiles
+   * TypeScript/TSX → JavaScript with a source map, then parseAstAsync parses
+   * the compiled JS, and astV8ToIstanbul maps positions back to the original
+   * source via the source map.
+   *
+   * Because the positions come from esbuild (identical to unit/component
+   * coverage), a subsequent `nextcov merge` rebase always finds exact
+   * line:col matches — no fallback, no misattribution.
    */
   private async createEmptyCoverage(
     filePath: string,
     code: string
   ): Promise<CoverageMapData | null> {
     try {
-      // Determine if it's TypeScript/TSX
-      const isTypeScript = filePath.endsWith('.ts') || filePath.endsWith('.tsx')
-      const isJSX = filePath.endsWith('.tsx') || filePath.endsWith('.jsx')
-
-      // Parse with Babel which supports TypeScript
-      const ast = babelParse(code, {
-        sourceType: 'module',
-        plugins: [
-          ...(isTypeScript ? ['typescript' as const] : []),
-          ...(isJSX ? ['jsx' as const] : []),
-          'decorators-legacy' as const,
-        ],
-        errorRecovery: true,
-      })
-
-      // Convert Windows path to file:// URL
       const fileUrl = toFileUrl(filePath, this.projectRoot)
 
-      // Use ast-v8-to-istanbul with the Babel AST
-      // Pass empty functions array to mark everything as uncovered
-      // Note: Babel AST is structurally compatible with astV8ToIstanbul's expected AST
+      // Transform TypeScript/TSX → JS using esbuild (same as Vitest's pipeline).
+      // sourcemap:true gives us the position mapping back to the original source.
+      //
+      // IMPORTANT: Use platform:'neutral' so esbuild does NOT constant-fold
+      // process.env.NODE_ENV branches. With the default platform ('browser'),
+      // esbuild sees NODE_ENV='production' in the env and eliminates the
+      // 'else' arm of `NODE_ENV === 'production' ? A : B`, producing fewer
+      // branches in the zero-coverage map than Vitest (which uses platform:'browser'
+      // but runs with NODE_ENV='test', so no constant-folding occurs there).
+      const { code: compiledCode, map } = await transformWithEsbuild(code, filePath, {
+        sourcemap: true,
+        platform: 'neutral',
+      })
+
+      // Parse the compiled JS with Vite's fast Rollup-based parser
+      const ast = await parseAstAsync(compiledCode)
+
+      // Build the source map for astV8ToIstanbul: mappings from compiled JS
+      // positions → original TypeScript positions, with the original file as source.
+      const sourceMap = map?.mappings ? {
+        version: 3 as const,
+        sources: [fileUrl],
+        sourcesContent: [code],
+        names: map.names ?? [],
+        mappings: map.mappings,
+      } : undefined
+
       const emptyCoverage = await astV8ToIstanbul({
-        code,
-        ast: ast as unknown as Parameters<typeof astV8ToIstanbul>[0]['ast'],
+        code: compiledCode,
+        ast,
+        sourceMap,
         coverage: {
           url: fileUrl,
-          functions: [], // No functions executed = 0% coverage
+          // A single block-coverage range spanning the entire file with count 0
+          // lets astV8ToIstanbul enumerate ALL statements, functions, and branches
+          // (including logical/ternary operators). With functions:[] it can only
+          // find branches discoverable from the AST alone, giving an incomplete
+          // denominator (e.g. 1192 instead of the correct 1228).
+          functions: [
+            {
+              functionName: '(root)',
+              isBlockCoverage: true,
+              ranges: [{ startOffset: 0, endOffset: compiledCode.length, count: 0 }],
+            },
+          ],
         },
         wrapperLength: 0,
         ignoreClassMethods: [],
@@ -997,7 +1024,6 @@ export class CoverageConverter {
       // Fix the path in the coverage data
       const result: CoverageMapData = {}
       for (const [, data] of Object.entries(emptyCoverage as CoverageMapData)) {
-        // FileCoverageData has a path property that we need to update
         const fileCoverage = data as CoverageMapData[string] & { path: string }
         fileCoverage.path = filePath
         result[filePath] = data

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -7,16 +7,17 @@
 
 import { join, resolve } from 'node:path'
 import { glob } from 'glob'
+import libCoverage from 'istanbul-lib-coverage'
 import { V8CoverageReader } from './v8-reader.js'
 import { SourceMapLoader } from './sourcemap-loader.js'
 import { CoverageConverter } from '@/converter/index.js'
 import { IstanbulReporter } from './reporter.js'
+import { rebaseOntoMap } from '@/merger/rebase.js'
 import {
   DEFAULT_NEXTCOV_CONFIG,
   DEFAULT_REPORTERS,
   DEFAULT_INCLUDE_PATTERNS,
   COVERAGE_FINAL_JSON,
-  normalizePath,
   isPathWithinBase,
 } from '@/utils/config.js'
 import type {
@@ -95,9 +96,16 @@ export class CoverageProcessor {
       mergedMap = await this.reporter.mergeCoverageMaps(mergedMap, coverageMap)
     }
 
-    // Add uncovered source files if configured
+    // Rebase E2E coverage onto the full source AST structure and fill in
+    // uncovered files. Requires sourceRoot to be configured.
+    //
+    // Turbopack collapses AST nodes during compilation, so V8 coverage sees
+    // fewer statements than the original source (e.g. 1315 vs 1771). Without
+    // rebasing, E2E-only reports show inflated percentages because the
+    // denominator is too small. We fix this here so the output is already
+    // correct whether or not the user runs `nextcov merge` afterwards.
     if (this.options.sourceRoot) {
-      await this.addUncoveredFiles(mergedMap)
+      mergedMap = await this.rebaseOntoSourceStructure(mergedMap)
     }
 
     // Generate reports
@@ -110,38 +118,68 @@ export class CoverageProcessor {
   }
 
   /**
-   * Add uncovered source files to coverage map
-   * Includes path traversal protection to ensure all files are within project root.
+   * Rebase E2E coverage onto the full source AST structure, then fill in
+   * uncovered files with zero hit counts.
+   *
+   * For every source file, Babel parses the TypeScript/TSX (static analysis
+   * only — no instrumentation) and ast-v8-to-istanbul derives the complete
+   * statement/function/branch map with zero counts. This "zero map" has the
+   * same rich granularity as Vitest/esbuild coverage.
+   *
+   * rebaseOntoMap then remaps E2E hit counts from the coarser Turbopack
+   * structure onto the richer zero-map skeleton by matching line:col positions.
+   *
+   * Finally, the zero map is used as the base so that files the browser never
+   * loaded appear in the report with zero counts (correct denominator).
+   *
+   * Babel parse cost is proportional to total source files, but runs once at
+   * the end of the test suite and is I/O-bound, not CPU-bound.
    */
-  private async addUncoveredFiles(coverageMap: CoverageMap): Promise<void> {
+  private async rebaseOntoSourceStructure(coverageMap: CoverageMap): Promise<CoverageMap> {
     const includePatterns = this.options.include || DEFAULT_INCLUDE_PATTERNS
     const excludePatterns = this.options.exclude || []
 
-    // Find all source files
-    const sourceFiles: string[] = []
+    // Collect all source files
+    const allSourceFiles: string[] = []
     for (const pattern of includePatterns) {
       const fullPattern = join(this.projectRoot, pattern).replace(/\\/g, '/')
       const ignorePatterns = excludePatterns.map((p) =>
         join(this.projectRoot, p).replace(/\\/g, '/')
       )
-      const files = await glob(fullPattern, {
-        ignore: ignorePatterns,
-        absolute: true,
-      })
-      sourceFiles.push(...files)
+      const files = await glob(fullPattern, { ignore: ignorePatterns, absolute: true })
+      allSourceFiles.push(...files)
+    }
+    // Path traversal protection
+    const safeFiles = allSourceFiles.filter((f) => isPathWithinBase(f, this.projectRoot))
+
+    // Build zero-count Istanbul map for all source files by parsing each file
+    // with Babel. Babel is used here only as a TypeScript/JSX-capable parser —
+    // it does not instrument or modify any code. The resulting zero map has the
+    // full source-accurate statement granularity that Turbopack loses at compile time.
+    const zeroMap = libCoverage.createCoverageMap({})
+    await this.converter.addUncoveredFiles(zeroMap, safeFiles)
+
+    log(`Built source structure for ${safeFiles.length} files`)
+
+    // Treat E2E rebase as: merge zero-coverage base with E2E coverage.
+    // This is the same pipeline as `nextcov merge` so statements, functions,
+    // AND branches are all handled consistently.
+    //
+    // Use rebaseOntoMap: the zero map is ALWAYS the authoritative structure skeleton.
+    // This avoids the isBabelQuality heuristic which breaks when esbuild produces
+    // Infinity end.column values that JSON.stringify serializes to null, causing
+    // rebaseCoarserMaps to incorrectly treat the zero map as non-babel-quality
+    // and pick the Turbopack structure instead.
+    // rebaseOntoMap already includes uncovered files (zero counts from structure),
+    // so no further merge with zeroMap is needed.
+    const merged = rebaseOntoMap(zeroMap, coverageMap)
+
+    const uncoveredCount = safeFiles.length - coverageMap.files().length
+    if (uncoveredCount > 0) {
+      log(`   Added ${uncoveredCount} uncovered source files with zero counts`)
     }
 
-    // Filter out files already in coverage
-    // Normalize paths to forward slashes for cross-platform comparison
-    const coveredFiles = new Set(coverageMap.files().map(normalizePath))
-    const uncoveredFiles = sourceFiles
-      .filter((f) => !coveredFiles.has(normalizePath(f)))
-      // Path traversal protection: ensure all files are within project root
-      .filter((f) => isPathWithinBase(f, this.projectRoot))
-
-    log(`Adding ${uncoveredFiles.length} source files for complete coverage...`)
-
-    await this.converter.addUncoveredFiles(coverageMap, uncoveredFiles)
+    return merged
   }
 
   /**
@@ -156,4 +194,3 @@ export class CoverageProcessor {
     return this.reporter.getSummary(coverageMap)
   }
 }
-

--- a/src/merger/rebase.ts
+++ b/src/merger/rebase.ts
@@ -52,7 +52,16 @@ export function rebaseCoarserMaps(maps: CoverageMap[]): CoverageMap[] {
     }
   }
 
-  // For each file, find the richest structure (most statements)
+  // For each file, find the richest structure (most statements) to use as the
+  // rebase skeleton. More statements = finer AST granularity = better skeleton.
+  //
+  // Note: isBabelQuality (end.column !== null) was previously used here to prefer
+  // esbuild/Vitest maps over Turbopack maps, but esbuild produces end.column: Infinity
+  // which JSON.stringify serializes to null — indistinguishable from Turbopack's null
+  // after a coverage-final.json round-trip. So statement count is the only reliable
+  // signal. When E2E coverage has been pre-rebased via rebaseOntoSourceStructure, both
+  // unit and E2E maps already share esbuild structure, so counts are similar and
+  // "most statements wins" produces correct results.
   const richestByFile = new Map<string, { stmtCount: number; mapIdx: number; data: FileCoverageData }>()
 
   for (let i = 0; i < maps.length; i++) {
@@ -110,12 +119,17 @@ export function rebaseCoarserMaps(maps: CoverageMap[]): CoverageMap[] {
 
       const rebased_b: Record<string, number[]> = {}
       for (const [key, branch] of Object.entries(richest.data.branchMap || {}) as [string, BranchEntry][]) {
+        const expectedLen = (branch as unknown as { locations: unknown[] }).locations?.length ?? 2
         const exact = lookups.branches.get(locationKey(branch.loc))
         if (exact !== undefined) {
-          rebased_b[key] = exact
+          rebased_b[key] = exact.length === expectedLen
+            ? exact
+            : Array.from({ length: expectedLen }, (_, i) => exact[i] ?? 0)
         } else {
           const byLine = lookups.branchesByLine.get(lineKey(branch.loc))
-          rebased_b[key] = byLine ?? new Array((branch as unknown as { locations: unknown[] }).locations?.length ?? 2).fill(0)
+          rebased_b[key] = byLine
+            ? Array.from({ length: expectedLen }, (_, i) => byLine[i] ?? 0)
+            : new Array(expectedLen).fill(0)
         }
       }
 
@@ -135,6 +149,79 @@ export function rebaseCoarserMaps(maps: CoverageMap[]): CoverageMap[] {
 
     return libCoverage.createCoverageMap(newMapData as unknown as Parameters<typeof libCoverage.createCoverageMap>[0])
   })
+}
+
+/**
+ * Rebase `source` coverage hits onto `structure`'s statement/fn/branch maps.
+ *
+ * Unlike rebaseCoarserMaps, the structure map is ALWAYS authoritative —
+ * its statementMap/fnMap/branchMap is used regardless of statement counts or
+ * quality tier. Use this when the caller knows which map is the correct
+ * skeleton (e.g. the esbuild zero-map in rebaseOntoSourceStructure).
+ *
+ * Files only in `source` (not in `structure`) are excluded — they fall
+ * outside the known source structure (include patterns).
+ *
+ * @param structure - Authoritative coverage map (esbuild zero-map)
+ * @param source    - Coverage to rebase hits from (E2E / Turbopack)
+ */
+export function rebaseOntoMap(structure: CoverageMap, source: CoverageMap): CoverageMap {
+  const newMapData: Record<string, FileCoverageData> = {}
+  const sourceFiles = new Set(source.files())
+
+  for (const file of structure.files()) {
+    const structureData = structure.fileCoverageFor(file).toJSON() as FileCoverageData
+
+    if (!sourceFiles.has(file)) {
+      // File not hit by E2E — keep zero counts from structure
+      newMapData[file] = structureData
+      continue
+    }
+
+    const sourceData = source.fileCoverageFor(file).toJSON() as FileCoverageData
+    const lookups = buildLookups(sourceData)
+
+    const rebased_s: Record<string, number> = {}
+    for (const [key, loc] of Object.entries(structureData.statementMap || {}) as [string, Location][]) {
+      const exact = lookups.stmts.get(locationKey(loc))
+      rebased_s[key] = exact !== undefined ? exact : (lookups.stmtsByLine.get(lineKey(loc)) ?? 0)
+    }
+
+    const rebased_f: Record<string, number> = {}
+    for (const [key, fn] of Object.entries(structureData.fnMap || {}) as [string, FnEntry][]) {
+      const exact = lookups.fns.get(locationKey(fn.loc))
+      rebased_f[key] = exact !== undefined ? exact : (lookups.fnsByLine.get(lineKey(fn.loc)) ?? 0)
+    }
+
+    const rebased_b: Record<string, number[]> = {}
+    for (const [key, branch] of Object.entries(structureData.branchMap || {}) as [string, BranchEntry][]) {
+      const expectedLen = (branch as unknown as { locations: unknown[] }).locations?.length ?? 2
+      const exact = lookups.branches.get(locationKey(branch.loc))
+      if (exact !== undefined) {
+        // Exact match: truncate/pad to the zero-map arm count so Turbopack
+        // branches with different arm counts don't inflate the denominator.
+        rebased_b[key] = exact.length === expectedLen
+          ? exact
+          : Array.from({ length: expectedLen }, (_, i) => exact[i] ?? 0)
+      } else {
+        const byLine = lookups.branchesByLine.get(lineKey(branch.loc))
+        // byLine comes from E2E source and may have more or fewer arms than the
+        // zero map branch. Always normalise to the zero map's expected arm count.
+        rebased_b[key] = byLine
+          ? Array.from({ length: expectedLen }, (_, i) => byLine[i] ?? 0)
+          : new Array(expectedLen).fill(0)
+      }
+    }
+
+    newMapData[file] = {
+      ...structureData,
+      s: rebased_s,
+      f: rebased_f,
+      b: rebased_b,
+    }
+  }
+
+  return libCoverage.createCoverageMap(newMapData as unknown as Parameters<typeof libCoverage.createCoverageMap>[0])
 }
 
 /**

--- a/src/playwright/fixture.ts
+++ b/src/playwright/fixture.ts
@@ -134,6 +134,15 @@ export interface PlaywrightCoverageOptions {
    * When false, client coverage from Playwright is not collected.
    */
   collectClient?: boolean
+  /**
+   * Number of worker threads for coverage processing (default: auto based on CPU count).
+   * Set to 0 to disable worker threads and run single-threaded.
+   *
+   * On Windows, setting workers: 0 avoids a heap corruption crash that occurs
+   * when Vite's WASM-based parser is loaded in worker threads while Playwright's
+   * Chromium process is still shutting down.
+   */
+  workers?: number
 }
 
 const DEFAULT_OPTIONS: Required<PlaywrightCoverageOptions> = {
@@ -150,6 +159,7 @@ const DEFAULT_OPTIONS: Required<PlaywrightCoverageOptions> = {
   cdpPort: DEFAULT_NEXTCOV_CONFIG.cdpPort,
   collectServer: DEFAULT_NEXTCOV_CONFIG.collectServer,
   collectClient: DEFAULT_NEXTCOV_CONFIG.collectClient,
+  workers: -1, // -1 = auto-detect
 }
 
 /**
@@ -495,6 +505,20 @@ export async function finalizeCoverage(
   options?: PlaywrightCoverageOptions | ResolvedNextcovConfig
 ): Promise<CoverageResult | null> {
   const opts = { ...DEFAULT_OPTIONS, ...options }
+
+  // Apply workers config before the worker pool is first accessed.
+  // workers: 0 disables worker threads (single-threaded mode).
+  // This is needed on Windows where Vite's WASM parser in worker threads
+  // causes heap corruption while Chromium is shutting down.
+  if (opts.workers >= 0) {
+    process.env.NEXTCOV_WORKERS = String(opts.workers)
+  }
+
+  // Initialize logging from config (needed when finalizeCoverage is called directly
+  // in globalTeardown without a prior startServerCoverage call)
+  const rawOpts = options as Record<string, unknown> | undefined
+  setLogging(rawOpts?.log === true)
+  setTiming(rawOpts?.timing === true)
 
   log('\n✅ E2E tests complete')
 

--- a/src/worker/pool.ts
+++ b/src/worker/pool.ts
@@ -109,12 +109,16 @@ interface QueuedTask {
   task: WorkerTask
   resolve: (result: WorkerResult) => void
   reject: (error: Error) => void
+  retries: number
 }
+
+const MAX_TASK_RETRIES = 2
 
 export class WorkerPool {
   private workers: Worker[] = []
   private availableWorkers: Worker[] = []
   private taskQueue: QueuedTask[] = []
+  private activeTask: Map<Worker, QueuedTask> = new Map()
   private workerPath: string
   private maxWorkers: number
   private isTerminated = false
@@ -129,7 +133,13 @@ export class WorkerPool {
   }
 
   private createWorker(): Worker {
-    const worker = new Worker(this.workerPath)
+    // Strip --input-type from execArgv — it is only valid for stdin/eval input
+    // and causes ERR_INPUT_TYPE_NOT_ALLOWED when worker threads inherit it from
+    // a parent process started with `node --input-type=module`.
+    const execArgv = process.execArgv.filter(
+      (arg) => !arg.startsWith('--input-type')
+    )
+    const worker = new Worker(this.workerPath, { execArgv })
 
     worker.on('error', (err) => {
       console.error('[WorkerPool] Worker error:', err)
@@ -157,6 +167,24 @@ export class WorkerPool {
       if (availIdx !== -1) {
         this.availableWorkers.splice(availIdx, 1)
       }
+      // Reject the in-flight task for this worker (if any) so its promise
+      // doesn't hang forever. Re-queue it so it gets retried on a new worker.
+      const active = this.activeTask.get(worker)
+      this.activeTask.delete(worker)
+      if (active && !this.isTerminated) {
+        if (active.retries < MAX_TASK_RETRIES) {
+          // Re-queue with incremented retry count
+          active.retries++
+          this.taskQueue.unshift(active)
+          this.processNextTask()
+        } else {
+          // Max retries exceeded — fall back to single-threaded execution
+          console.warn('[WorkerPool] Worker repeatedly crashed, falling back to single-threaded mode for this task')
+          this.runTaskDirect(active.task).then(active.resolve).catch(active.reject)
+        }
+      } else if (active) {
+        active.reject(new Error(`Worker exited with code ${code ?? 'null'}`))
+      }
     })
 
     this.workers.push(worker)
@@ -180,11 +208,14 @@ export class WorkerPool {
     const worker = this.getWorker()
     if (!worker) return
 
-    const { task, resolve, reject } = this.taskQueue.shift()!
+    const queued = this.taskQueue.shift()!
+    const { task, resolve, reject } = queued
+    this.activeTask.set(worker, queued)
 
     const handleMessage = (result: WorkerResult) => {
       worker.off('message', handleMessage)
       worker.off('error', handleError)
+      this.activeTask.delete(worker)
 
       // Return worker to available pool
       if (!this.isTerminated) {
@@ -199,6 +230,7 @@ export class WorkerPool {
     const handleError = (err: Error) => {
       worker.off('message', handleMessage)
       worker.off('error', handleError)
+      this.activeTask.delete(worker)
 
       reject(err)
     }
@@ -221,7 +253,7 @@ export class WorkerPool {
     }
 
     return new Promise((resolve, reject) => {
-      this.taskQueue.push({ task, resolve, reject })
+      this.taskQueue.push({ task, resolve, reject, retries: 0 })
       this.processNextTask()
     })
   }


### PR DESCRIPTION
## Summary

- **Rebase E2E coverage onto source AST structure** — `processAllCoverage` now rebases Turbopack-coarsened E2E coverage onto a zero-count esbuild map built from all source files. Hit counts are remapped by `line:col` position, uncovered files get zero counts, and the denominator matches Vitest exactly. Requires `sourceRoot` in config.
- **`rebaseOntoMap`** — new function in `src/merger/rebase.ts` where the caller supplies the authoritative skeleton (no heuristic). Branch arm arrays are normalised to the skeleton's `locations.length` to prevent denominator inflation from Turbopack's differently-shaped branch nodes.
- **`workers` option for `PlaywrightCoverageOptions`** — set `workers: 0` in `finalizeCoverage` config to disable worker threads. Fixes Windows heap corruption (`0xC0000374`) when Vite's WASM parser runs in worker threads while Chromium is shutting down.
- **`isBabelQuality` removed from `rebaseCoarserMaps`** — esbuild produces `end.column: Infinity` which JSON.stringify serialises to `null`, indistinguishable from Turbopack after a `coverage-final.json` round-trip. The heuristic was silently picking Turbopack's coarser structure as the skeleton. Reverted to "most statements wins". Safe because E2E is pre-rebased before `nextcov merge` reads it.
- **Worker pool crash loop fix** — added `MAX_TASK_RETRIES = 2`; after two retries falls back to `runTaskDirect` (main thread). Also strips `--input-type=module` from worker `execArgv` to fix `ERR_INPUT_TYPE_NOT_ALLOWED`.
- **Branch denominator fix** — byLine fallback arm arrays are now truncated/padded to the zero-map branch's `locations.length`, preventing inflation (e.g. 1249 → 1230).
- **Logging init in `finalizeCoverage`** — `setLogging`/`setTiming` now called from config when `finalizeCoverage` is invoked directly in globalTeardown without a prior `startServerCoverage`.

## Test plan

- [ ] E2E-only report branch count matches Vitest denominator (1230, not 1249 or 1192)
- [ ] Merged (unit + component + E2E) coverage reaches 100%
- [ ] `workers: 0` in globalTeardown config prevents Windows heap crash
- [ ] Unit tests pass: `src/merger/__tests__/rebase.test.ts`, `src/__tests__/processor.test.ts`, `src/__tests__/converter.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)