### PR TITLE
chore: release v1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [1.4.3] - 2026-06-30
 
+### Added
+
+- **Respect `c8`/`istanbul` ignore hints in E2E and merged coverage** — `processAllCoverage` now strips statements, functions, and branches annotated with `// c8 ignore next`, `/* c8 ignore next */`, `/* c8 ignore start */.../* c8 ignore stop */` (and `istanbul` variants) from E2E coverage before generating reports. `nextcov merge --strip` applies the same stripping to merged coverage. This makes E2E and merged reports consistent with Vitest, which respects these hints at collection time.
+
 ### Changed
 
 - **Bump dev dependencies** — Updated `@eslint/js`, `eslint`, `typescript-eslint`, `@playwright/test`, `@types/node`, `rimraf`, and `tsc-alias` to latest versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.3] - 2026-06-30
+
+### Changed
+
+- **Bump dev dependencies** — Updated `@eslint/js`, `eslint`, `typescript-eslint`, `@playwright/test`, `@types/node`, `rimraf`, and `tsc-alias` to latest versions.
+
+### Fixed
+
+- **Pin TypeScript to `^5`** — TypeScript 6 breaks tsup 8.x's DTS generation (`rollup-plugin-dts` does not yet support TS6), causing `.d.ts` files to be silently omitted from the build output. TypeScript is pinned to `^5` until tsup adds TS6 support.
+
 ## [1.4.2] - 2026-06-30
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextcov",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nextcov",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.24.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcov",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Collect test coverage for Playwright E2E tests in Next.js applications",
   "author": "Steve Zhang",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Bump dev dependencies (eslint 10, typescript-eslint, @playwright/test, @types/node, rimraf, tsc-alias)
- Pin TypeScript to `^5` — TypeScript 6 breaks tsup 8.x DTS generation (`rollup-plugin-dts` doesn't support TS6 yet), causing `.d.ts` files to be silently omitted from the build output
- Add CHANGELOG entry for c8/istanbul ignore hints feature (merged in #69)

## Test plan

- [ ] `npm run build` completes with DTS files generated (`dist/index.d.ts`, `dist/playwright/index.d.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)