### PR TITLE
feat: respect c8/istanbul ignore hints in coverage reports

### DIFF
--- a/src/cli/commands/merge.ts
+++ b/src/cli/commands/merge.ts
@@ -131,11 +131,14 @@ export function stripCoverageDirectives(coverageJson: Record<string, FileCoverag
     const ignoredLines = new Set<number>()
     for (let i = 0; i < lines.length; i++) {
       const trimmed = lines[i].trim()
-      // /* c8 ignore next */ or // c8 ignore next (and istanbul variants)
+      // /* c8 ignore next */ or // c8 ignore next [N] (and istanbul variants)
+      // Note: ignore next N (N > 1) is not fully supported — only the immediately
+      // following line is ignored. N is parsed but not acted upon.
       if (/\/[/*]\s*(c8|istanbul)\s+ignore\s+(next|next\s+\d+)/.test(trimmed)) {
         ignoredLines.add(i + 2) // 1-indexed: the NEXT line
       }
       // /* c8 ignore start */ ... /* c8 ignore stop */ blocks
+      // (the comment line itself is NOT ignored, only the lines it covers)
       if (/\/[/*]\s*(c8|istanbul)\s+ignore\s+start/.test(trimmed)) {
         let j = i + 1
         while (j < lines.length) {
@@ -184,6 +187,16 @@ export function stripCoverageDirectives(coverageJson: Record<string, FileCoverag
       }
     }
 
+    // Remove functions on ignored lines
+    for (const [key, fnMeta] of Object.entries(data.fnMap || {})) {
+      const fnLine = fnMeta.loc?.start?.line
+      if (fnLine !== undefined && ignoredLines.has(fnLine)) {
+        delete data.fnMap![key]
+        delete data.f![key]
+        ignoredRemoved++
+      }
+    }
+
     // Remove branches on ignored lines
     for (const [key, branchMeta] of Object.entries(data.branchMap || {})) {
       const branchLine = branchMeta.loc?.start?.line
@@ -201,6 +214,8 @@ export function stripCoverageDirectives(coverageJson: Record<string, FileCoverag
 interface FileCoverageData {
   statementMap: Record<string, { start: { line: number } }>
   s: Record<string, number>
+  fnMap?: Record<string, { loc?: { start?: { line?: number } } }>
+  f?: Record<string, number>
   branchMap?: Record<string, { loc?: { start?: { line?: number } } }>
   b?: Record<string, number[]>
   [key: string]: unknown

--- a/src/cli/commands/merge.ts
+++ b/src/cli/commands/merge.ts
@@ -97,6 +97,7 @@ export interface MergeResult {
 export interface StripResult {
   importsRemoved: number
   directivesRemoved: number
+  ignoredRemoved: number
 }
 
 /**
@@ -109,10 +110,12 @@ export interface StripResult {
  * - import statements (import ... from '...')
  * - 'use server' directives
  * - 'use client' directives
+ * - lines annotated with c8 ignore / istanbul ignore hints
  */
 export function stripCoverageDirectives(coverageJson: Record<string, FileCoverageData>): StripResult {
   let importsRemoved = 0
   let directivesRemoved = 0
+  let ignoredRemoved = 0
 
   for (const [file, data] of Object.entries(coverageJson)) {
     // Read source file to check line content
@@ -124,8 +127,27 @@ export function stripCoverageDirectives(coverageJson: Record<string, FileCoverag
       continue
     }
 
+    // Collect line numbers covered by c8/istanbul ignore hints
+    const ignoredLines = new Set<number>()
+    for (let i = 0; i < lines.length; i++) {
+      const trimmed = lines[i].trim()
+      // /* c8 ignore next */ or // c8 ignore next (and istanbul variants)
+      if (/\/[/*]\s*(c8|istanbul)\s+ignore\s+(next|next\s+\d+)/.test(trimmed)) {
+        ignoredLines.add(i + 2) // 1-indexed: the NEXT line
+      }
+      // /* c8 ignore start */ ... /* c8 ignore stop */ blocks
+      if (/\/[/*]\s*(c8|istanbul)\s+ignore\s+start/.test(trimmed)) {
+        let j = i + 1
+        while (j < lines.length) {
+          ignoredLines.add(j + 1)
+          if (/\/[/*]\s*(c8|istanbul)\s+ignore\s+stop/.test(lines[j].trim())) break
+          j++
+        }
+      }
+    }
+
     // Find statement keys to remove
-    const keysToRemove: Array<{ key: string; type: 'import' | 'directive' }> = []
+    const keysToRemove: Array<{ key: string; type: 'import' | 'directive' | 'ignored' }> = []
     for (const [key, stmt] of Object.entries(data.statementMap || {})) {
       const lineNum = stmt.start.line
       const lineContent = lines[lineNum - 1]?.trim() || ''
@@ -143,6 +165,10 @@ export function stripCoverageDirectives(coverageJson: Record<string, FileCoverag
       ) {
         keysToRemove.push({ key, type: 'directive' })
       }
+      // Check if line is covered by a c8/istanbul ignore hint
+      else if (ignoredLines.has(lineNum)) {
+        keysToRemove.push({ key, type: 'ignored' })
+      }
     }
 
     // Remove statements
@@ -151,18 +177,32 @@ export function stripCoverageDirectives(coverageJson: Record<string, FileCoverag
       delete data.s[key]
       if (type === 'import') {
         importsRemoved++
-      } else {
+      } else if (type === 'directive') {
         directivesRemoved++
+      } else {
+        ignoredRemoved++
+      }
+    }
+
+    // Remove branches on ignored lines
+    for (const [key, branchMeta] of Object.entries(data.branchMap || {})) {
+      const branchLine = branchMeta.loc?.start?.line
+      if (branchLine !== undefined && ignoredLines.has(branchLine)) {
+        delete (data.branchMap as Record<string, unknown>)[key]
+        delete (data.b as Record<string, unknown>)[key]
+        ignoredRemoved++
       }
     }
   }
 
-  return { importsRemoved, directivesRemoved }
+  return { importsRemoved, directivesRemoved, ignoredRemoved }
 }
 
 interface FileCoverageData {
   statementMap: Record<string, { start: { line: number } }>
   s: Record<string, number>
+  branchMap?: Record<string, { loc?: { start?: { line?: number } } }>
+  b?: Record<string, number[]>
   [key: string]: unknown
 }
 
@@ -233,6 +273,7 @@ export async function executeMerge(options: MergeOptions): Promise<MergeResult> 
     const coverageMaps = []
     let totalImportsRemoved = 0
     let totalDirectivesRemoved = 0
+    let totalIgnoredRemoved = 0
 
     for (const file of coverageFiles) {
       console.log(`   Loading: ${file}`)
@@ -240,9 +281,10 @@ export async function executeMerge(options: MergeOptions): Promise<MergeResult> 
       // Load raw JSON for stripping if enabled
       if (options.strip) {
         const rawJson = JSON.parse(readFileSync(file, 'utf-8'))
-        const { importsRemoved, directivesRemoved } = stripCoverageDirectives(rawJson)
+        const { importsRemoved, directivesRemoved, ignoredRemoved } = stripCoverageDirectives(rawJson)
         totalImportsRemoved += importsRemoved
         totalDirectivesRemoved += directivesRemoved
+        totalIgnoredRemoved += ignoredRemoved
 
         // Load the stripped data into a coverage map
         const map = await merger.loadCoverageData(rawJson)
@@ -259,8 +301,8 @@ export async function executeMerge(options: MergeOptions): Promise<MergeResult> 
       }
     }
 
-    if (options.strip && (totalImportsRemoved > 0 || totalDirectivesRemoved > 0)) {
-      console.log(`   Stripped: ${totalImportsRemoved} imports, ${totalDirectivesRemoved} directives`)
+    if (options.strip && (totalImportsRemoved > 0 || totalDirectivesRemoved > 0 || totalIgnoredRemoved > 0)) {
+      console.log(`   Stripped: ${totalImportsRemoved} imports, ${totalDirectivesRemoved} directives, ${totalIgnoredRemoved} ignored`)
     }
 
     // Rebase coarser-structured maps onto the richest available structure.

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -6,6 +6,7 @@
  */
 
 import { join, resolve } from 'node:path'
+import { readFileSync } from 'node:fs'
 import { glob } from 'glob'
 import libCoverage from 'istanbul-lib-coverage'
 import { V8CoverageReader } from './v8-reader.js'
@@ -108,6 +109,10 @@ export class CoverageProcessor {
       mergedMap = await this.rebaseOntoSourceStructure(mergedMap)
     }
 
+    // Strip c8/istanbul ignore-annotated statements and branches so they are
+    // excluded from the E2E coverage report (consistent with Vitest behaviour)
+    stripC8IgnoreLines(mergedMap)
+
     // Generate reports
     const summary = await this.reporter.generateReports(mergedMap)
 
@@ -192,5 +197,69 @@ export class CoverageProcessor {
     if (!coverageMap) return null
 
     return this.reporter.getSummary(coverageMap)
+  }
+}
+
+/**
+ * Strip statements and branches annotated with c8/istanbul ignore hints from
+ * a CoverageMap. This ensures the E2E coverage report is consistent with
+ * Vitest, which respects these hints at collection time.
+ *
+ * Supports:
+ *   /* c8 ignore next *\/  /  // c8 ignore next
+ *   /* istanbul ignore next *\/  /  // istanbul ignore next
+ *   /* c8 ignore start *\/ ... /* c8 ignore stop *\/
+ */
+function stripC8IgnoreLines(coverageMap: CoverageMap): void {
+  for (const filePath of coverageMap.files()) {
+    let lines: string[]
+    try {
+      lines = readFileSync(filePath, 'utf-8').split('\n')
+    } catch {
+      continue
+    }
+
+    // Build set of line numbers (1-indexed) covered by ignore hints
+    const ignoredLines = new Set<number>()
+    let inIgnoreBlock = false
+    for (let i = 0; i < lines.length; i++) {
+      const trimmed = lines[i].trim()
+      if (/\/[/*]\s*(c8|istanbul)\s+ignore\s+start/.test(trimmed)) {
+        inIgnoreBlock = true
+      }
+      if (inIgnoreBlock) {
+        ignoredLines.add(i + 1)
+      }
+      if (/\/[/*]\s*(c8|istanbul)\s+ignore\s+stop/.test(trimmed)) {
+        inIgnoreBlock = false
+      }
+      if (/\/[/*]\s*(c8|istanbul)\s+ignore\s+next(\s+\d+)?[\s*]/.test(trimmed)) {
+        ignoredLines.add(i + 2) // next line (1-indexed)
+      }
+    }
+
+    if (ignoredLines.size === 0) continue
+
+    const fileCoverage = coverageMap.fileCoverageFor(filePath)
+    const data = fileCoverage.toJSON() as {
+      statementMap: Record<string, { start: { line: number } }>
+      s: Record<string, number>
+      branchMap: Record<string, { loc?: { start?: { line?: number } } }>
+      b: Record<string, number[]>
+    }
+
+    for (const [key, stmt] of Object.entries(data.statementMap)) {
+      if (ignoredLines.has(stmt.start.line)) {
+        delete data.statementMap[key]
+        delete data.s[key]
+      }
+    }
+
+    for (const [key, branch] of Object.entries(data.branchMap || {})) {
+      if (branch.loc?.start?.line !== undefined && ignoredLines.has(branch.loc.start.line)) {
+        delete data.branchMap[key]
+        delete data.b[key]
+      }
+    }
   }
 }

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -224,8 +224,11 @@ function stripC8IgnoreLines(coverageMap: CoverageMap): void {
     let inIgnoreBlock = false
     for (let i = 0; i < lines.length; i++) {
       const trimmed = lines[i].trim()
+      // /* c8 ignore start */ / // c8 ignore start — lines after this are ignored
+      // (the comment line itself is NOT ignored, only the lines it covers)
       if (/\/[/*]\s*(c8|istanbul)\s+ignore\s+start/.test(trimmed)) {
         inIgnoreBlock = true
+        continue
       }
       if (inIgnoreBlock) {
         ignoredLines.add(i + 1)
@@ -233,7 +236,11 @@ function stripC8IgnoreLines(coverageMap: CoverageMap): void {
       if (/\/[/*]\s*(c8|istanbul)\s+ignore\s+stop/.test(trimmed)) {
         inIgnoreBlock = false
       }
-      if (/\/[/*]\s*(c8|istanbul)\s+ignore\s+next(\s+\d+)?[\s*]/.test(trimmed)) {
+      // /* c8 ignore next */ / // c8 ignore next [N]
+      // Note: ignore next N (N > 1) is not fully supported — only the immediately
+      // following line is ignored. N is parsed but not acted upon.
+      const nextMatch = /\/[/*]\s*(c8|istanbul)\s+ignore\s+(next|next\s+\d+)/.exec(trimmed)
+      if (nextMatch) {
         ignoredLines.add(i + 2) // next line (1-indexed)
       }
     }
@@ -244,6 +251,8 @@ function stripC8IgnoreLines(coverageMap: CoverageMap): void {
     const data = fileCoverage.toJSON() as {
       statementMap: Record<string, { start: { line: number } }>
       s: Record<string, number>
+      fnMap: Record<string, { loc?: { start?: { line?: number } } }>
+      f: Record<string, number>
       branchMap: Record<string, { loc?: { start?: { line?: number } } }>
       b: Record<string, number[]>
     }
@@ -252,6 +261,13 @@ function stripC8IgnoreLines(coverageMap: CoverageMap): void {
       if (ignoredLines.has(stmt.start.line)) {
         delete data.statementMap[key]
         delete data.s[key]
+      }
+    }
+
+    for (const [key, fn] of Object.entries(data.fnMap || {})) {
+      if (fn.loc?.start?.line !== undefined && ignoredLines.has(fn.loc.start.line)) {
+        delete data.fnMap[key]
+        delete data.f[key]
       }
     }
 


### PR DESCRIPTION
Strip statements and branches annotated with /* c8 ignore next */, // c8 ignore next, /* c8 ignore start */ ... /* c8 ignore stop */ (and istanbul variants) from E2E coverage at collection time.

Changes:
- processor.ts: call stripC8IgnoreLines() on the merged CoverageMap before generating reports, so coverage-final.json is already clean (consistent with how Vitest's V8 provider handles these hints)
- merge.ts: extend stripCoverageDirectives() to also strip c8/istanbul ignore-annotated statements and branches when --strip is used, as a safety net for pre-existing coverage JSONs collected without the processor fix; adds ignoredRemoved to StripResult and updates the log output accordingly