### PR TITLE
fix: add esbuild as direct dependency for Vite 8 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.5.1] - 2026-07-10
+
+### Fixed
+
+- **Add `esbuild` as a direct dependency** — Vite 8 no longer bundles esbuild (it became a peer dependency of Vite). nextcov uses `transformWithEsbuild` to compile TypeScript/TSX for zero-coverage generation, so esbuild must be present. Adding it as an explicit dependency ensures it is installed automatically alongside nextcov without requiring users to install it manually.
+
 ## [1.5.0] - 2026-07-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ npm install nextcov --save-dev
 
 ## Requirements
 
-- Node.js >= 20
+- Node.js >= 22
 - Next.js 14+ or Vite 5+
 - Playwright 1.40+
 
@@ -81,6 +81,8 @@ npm install nextcov --save-dev
 ```bash
 npm install @playwright/test --save-dev
 ```
+
+> **Note:** `esbuild` is included as a direct dependency of nextcov (required since Vite 8 no longer bundles it). It will be installed automatically — no manual installation needed.
 
 ## Quick Setup with `nextcov init`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextcov",
-  "version": "1.4.3",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nextcov",
-      "version": "1.4.3",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.24.0",
@@ -17,6 +17,7 @@
         "ast-v8-to-istanbul": "^1.0.4",
         "chalk": "^4.1.2",
         "convert-source-map": "^2.0.0",
+        "esbuild": ">=0.21.0",
         "glob": "^11.1.0",
         "istanbul-lib-coverage": "^3.2.0",
         "istanbul-lib-report": "^3.0.1",
@@ -2738,7 +2739,6 @@
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
       "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcov",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Collect test coverage for Playwright E2E tests in Next.js applications",
   "author": "Steve Zhang",
   "license": "MIT",
@@ -63,6 +63,7 @@
     "ast-v8-to-istanbul": "^1.0.4",
     "chalk": "^4.1.2",
     "convert-source-map": "^2.0.0",
+    "esbuild": ">=0.21.0",
     "glob": "^11.1.0",
     "istanbul-lib-coverage": "^3.2.0",
     "istanbul-lib-report": "^3.0.1",


### PR DESCRIPTION
## Summary

- Vite 8 no longer bundles esbuild — it became a peer dependency of Vite itself
- `nextcov` uses `transformWithEsbuild` to compile TypeScript/TSX for zero-coverage generation, so esbuild must be present at runtime
- Adding `"esbuild": ">=0.21.0"` as a direct dependency ensures it is installed automatically, avoiding a runtime crash for users who don't have esbuild in their project

## Changes

- `package.json` — add `esbuild >= 0.21.0` to `dependencies`, bump version to `1.5.1`
- `package-lock.json` — updated to reflect the new direct dependency
- `CHANGELOG.md` — add `[1.5.1]` entry
- `README.md` — fix Node.js engine requirement (`>= 20` → `>= 22`) and add a note explaining that esbuild is now a direct dep

## Test plan

- [ ] `npm install nextcov` in a fresh project (no prior esbuild) — verify esbuild is installed automatically
- [ ] Run E2E coverage collection end-to-end — verify zero-coverage generation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)